### PR TITLE
chore: ignore local AGENTS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ bin/
 *.bak
 *.tmp
 *.~ 
+AGENTS.md


### PR DESCRIPTION
ignore `AGENTS.md` so repo-specific agent instructions can stay local