### PR TITLE
feat: make package installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 Repository of not very useful optimizers in `PyTorch`.
 
+## Install with uv
+
+Add the package from GitHub:
+
+```bash
+uv add git+https://github.com/kovacoj/optimizers.git
+```
+
+For local development after cloning the repo:
+
+```bash
+uv venv
+uv pip install -e .
+```
+
+Because this repository uses a `src` layout, importing directly from the repo checkout without installing requires `PYTHONPATH=src`.
+
+## Use
+
+```python
+from optimizers import KalmanFilter
+```
+
+`KalmanFilter` is an alias for `ExtendedKalmanFilter`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,13 @@ requires-python = ">=3.13"
 dependencies = [
     "torch>=2.9.1",
 ]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/optimizers/__init__.py
+++ b/src/optimizers/__init__.py
@@ -4,10 +4,13 @@ from .Annealing import Annealing
 from .LevenbergMarquardt import LevenbergMarquardt
 from .ExtendedKalmanFilter import ExtendedKalmanFilter
 
+KalmanFilter = ExtendedKalmanFilter
+
 __all__ = [
     "Genetic",
     "Newton",
     "Annealing",
     "LevenbergMarquardt",
-    "ExtendedKalmanFilter"
+    "ExtendedKalmanFilter",
+    "KalmanFilter",
 ]


### PR DESCRIPTION
## Summary
- add minimal setuptools build metadata for the `src` layout so `uv` can install the package
- export `KalmanFilter` as an alias for `ExtendedKalmanFilter` so downstream imports can use `from optimizers import KalmanFilter`