### PR TITLE
test: add optimizer smoke tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ dependencies = [
     "torch>=2.9.1",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+]
+
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
@@ -17,3 +22,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,70 @@
+import torch
+
+from optimizers import Annealing
+from optimizers import ExtendedKalmanFilter
+from optimizers import Genetic
+from optimizers import LevenbergMarquardt
+from optimizers import Newton
+from optimizers.Metropolis import Metropolis
+
+
+def _scalar_param(value=1.0):
+    return torch.nn.Parameter(torch.tensor([value]))
+
+
+def _vector_param(values=(1.0, -1.0)):
+    return torch.nn.Parameter(torch.tensor(values))
+
+
+def test_newton_step_runs():
+    x = _scalar_param()
+    optimizer = Newton([x])
+
+    optimizer.step(lambda: (x ** 2).sum())
+
+
+def test_annealing_step_runs():
+    x = _scalar_param()
+    optimizer = Annealing([x])
+
+    loss = optimizer.step(lambda: (x ** 2).sum())
+
+    assert isinstance(loss, torch.Tensor)
+
+
+def test_metropolis_step_runs():
+    x = _scalar_param()
+    optimizer = Metropolis([x])
+
+    loss = optimizer.step(lambda: (x ** 2).sum())
+
+    assert isinstance(loss, torch.Tensor)
+
+
+def test_genetic_step_runs_with_small_population():
+    x = _vector_param()
+    optimizer = Genetic([x])
+    optimizer.pop_size = 4
+    optimizer.population = optimizer.params.unsqueeze(0).repeat(optimizer.pop_size, 1)
+
+    loss = optimizer.step(lambda: (x ** 2).sum())
+
+    assert isinstance(loss, torch.Tensor)
+
+
+def test_levenberg_marquardt_step_runs():
+    x = _scalar_param()
+    optimizer = LevenbergMarquardt([x])
+
+    loss = optimizer.step(lambda: x.view(-1))
+
+    assert isinstance(loss, float)
+
+
+def test_extended_kalman_filter_step_runs():
+    x = _scalar_param()
+    optimizer = ExtendedKalmanFilter([x])
+
+    loss = optimizer.step(lambda: x.view(-1))
+
+    assert isinstance(loss, torch.Tensor)


### PR DESCRIPTION
## Summary
- add a minimal smoke test suite that verifies each current optimizer can be instantiated and run for one step
- cover each optimizer with the closure contract it currently expects, including a reduced `Genetic.pop_size` for fast test execution