### PR TITLE
ci: add smoke test workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,29 @@
+name: smoke-tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run smoke tests
+        run: uv run --group dev pytest


### PR DESCRIPTION
## Summary
- add a minimal GitHub Actions workflow that installs the project with `uv`
- run the optimizer smoke test suite on pull requests and pushes to `main`