### PR TITLE
feat: add linear kalman filter optimizer

### DIFF
--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -1,0 +1,65 @@
+import torch
+
+
+class KalmanFilter(torch.optim.Optimizer):
+    # only one parameter group can be used!
+    # closure() returns (errors, H)
+    def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
+        self.eta, self.eps, self.q, self.tau = eta, eps, q, tau
+
+        defaults = dict(
+                    eta = self.eta,
+                    eps = self.eps,
+                    q = self.q,
+                    tau = self.tau
+                )
+        
+        super(KalmanFilter, self).__init__(params, defaults)
+
+        self.numel = sum(param.numel() for group in self.param_groups for param in group['params'] if param.requires_grad)
+
+        prototype = self.param_groups[0]['params'][0]
+
+        self.P = torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
+        self.Q = self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
+
+    def loss(self, errors):
+        # MSE loss, not divided by number of data, doesn't matter
+        return errors @ errors
+    
+    @torch.no_grad()
+    def update_weights(self, updates):
+        # maybe could be optimzed using torch.chunk
+        # Add the updates into the model
+        start_idx = 0
+        for group in self.param_groups:
+            for param in group['params']:
+                param.data.add_(updates[start_idx:start_idx + param.numel()].view(param.size()))
+                start_idx += param.numel()
+
+    def step(self, closure = None):
+
+        assert len(self.param_groups) == 1
+
+        # Make sure the closure is always called with grad enabled
+        closure = torch.enable_grad()(closure)
+
+        # closure (callable) - reevaluates the model and returns the residuals and linear observation matrix
+        errors, H = closure()
+        errors = errors.view(-1)
+
+        P = self.P / self.tau + self.Q
+
+        A = H @ P @ H.T + ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+
+        K = torch.linalg.solve(A, H @ P).T
+
+        updates = -(K @ errors).view(-1)
+
+        self.update_weights(updates)
+
+        self.P = P - K @ H @ P
+
+        errors, _ = closure()
+
+        return self.loss(errors.view(-1))

--- a/src/optimizers/__init__.py
+++ b/src/optimizers/__init__.py
@@ -2,15 +2,14 @@ from .Genetic import Genetic
 from .Newton import Newton
 from .Annealing import Annealing
 from .LevenbergMarquardt import LevenbergMarquardt
+from .KalmanFilter import KalmanFilter
 from .ExtendedKalmanFilter import ExtendedKalmanFilter
-
-KalmanFilter = ExtendedKalmanFilter
 
 __all__ = [
     "Genetic",
     "Newton",
     "Annealing",
     "LevenbergMarquardt",
-    "ExtendedKalmanFilter",
     "KalmanFilter",
+    "ExtendedKalmanFilter",
 ]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,6 +3,7 @@ import torch
 from optimizers import Annealing
 from optimizers import ExtendedKalmanFilter
 from optimizers import Genetic
+from optimizers import KalmanFilter
 from optimizers import LevenbergMarquardt
 from optimizers import Newton
 from optimizers.Metropolis import Metropolis
@@ -66,5 +67,19 @@ def test_extended_kalman_filter_step_runs():
     optimizer = ExtendedKalmanFilter([x])
 
     loss = optimizer.step(lambda: x.view(-1))
+
+    assert isinstance(loss, torch.Tensor)
+
+
+def test_kalman_filter_step_runs():
+    x = _scalar_param()
+    optimizer = KalmanFilter([x])
+
+    def closure():
+        errors = x.view(-1)
+        H = torch.eye(1, device=x.device, dtype=x.dtype)
+        return errors, H
+
+    loss = optimizer.step(closure)
 
     assert isinstance(loss, torch.Tensor)


### PR DESCRIPTION
## Summary
- add a real separate `KalmanFilter` optimizer for linear residual models where `closure()` returns `(errors, H)`
- export the new optimizer publicly and cover it with the smoke test suite