### PR TITLE
docs: rename tests workflow and update README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: smoke-tests
+name: Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  smoke-tests:
+  tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,5 +25,5 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Run smoke tests
+      - name: Run tests
         run: uv run --group dev pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# optimizers
+
+[![Tests](https://github.com/kovacoj/optimizers/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/kovacoj/optimizers/actions/workflows/tests.yml)
+
 Repository of not very useful optimizers in `PyTorch`.
 
 ## Install with uv
@@ -37,4 +41,4 @@ Because this repository uses a `src` layout, importing directly from the repo ch
 from optimizers import KalmanFilter
 ```
 
-`KalmanFilter` is an alias for `ExtendedKalmanFilter`.
+`KalmanFilter` expects `closure()` to return `(errors, H)`, while `ExtendedKalmanFilter` computes the Jacobian from a residual-vector closure.


### PR DESCRIPTION
## Summary
- rename the GitHub Actions workflow from `smoke-tests` to `Tests`
- update the README badge and Kalman optimizer note to match the current repository state