### PR TITLE
fix: align Newton and LM temp tensors

### DIFF
--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -22,13 +22,21 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         self.numel = sum(param.numel() for group in self.param_groups for param in group['params'] if param.requires_grad)
         # self.numel = reduce(lambda total, p: total + p.numel(), self.param_groups, 0)
 
+        self.prototype = self.param_groups[0]['params'][0]
+
     # @torch.compile ?
     def jacobian(self, targets):
         # needs to be tested (nn design)
-        J = torch.empty(targets.shape[0], self.numel)
+        J = targets.new_empty(targets.shape[0], self.numel)
         
         for i in range(targets.shape[0]):
-            J[i] = torch.hstack([d.view(1, -1) if d is not None else torch.tensor([0.]).view(1, -1) for d in grad(targets[i], self.param_groups[0]['params'], create_graph=True, retain_graph=True, allow_unused=True)])
+            J[i] = torch.hstack([
+                d.view(1, -1) if d is not None else param.new_zeros(1, param.numel())
+                for param, d in zip(
+                    self.param_groups[0]['params'],
+                    grad(targets[i], self.param_groups[0]['params'], create_graph=True, retain_graph=True, allow_unused=True)
+                )
+            ])
 
         return J
     
@@ -64,7 +72,7 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         J = self.jacobian(errors)
 
         # compute updates %torch.diag(J.T @ J)%
-        updates = -torch.inverse(J.T @ J + (self.mu+1e-8)*torch.eye(self.numel)) @ J.T @ errors
+        updates = -torch.inverse(J.T @ J + (self.mu+1e-8)*torch.eye(self.numel, device=self.prototype.device, dtype=self.prototype.dtype)) @ J.T @ errors
 
         self.update_weights(updates)
 
@@ -81,7 +89,7 @@ class LevenbergMarquardt(torch.optim.Optimizer):
             self.mu *= self.mu_factor
 
             # compute new updates
-            updates = -torch.inverse(J.T @ J + (self.mu+1e-8)*torch.eye(self.numel)) @ J.T @ errors
+            updates = -torch.inverse(J.T @ J + (self.mu+1e-8)*torch.eye(self.numel, device=self.prototype.device, dtype=self.prototype.dtype)) @ J.T @ errors
 
             # update weights
             self.update_weights(update = +updates)

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -29,16 +29,20 @@ class Newton(torch.optim.Optimizer):
                 offset += numel
 
     def step(self, closure: callable):
+        assert len(self.param_groups) == 1
+
+        prototype = self.param_groups[0]['params'][0]
+
         grads = grad(closure(), self.param_groups[0]['params'], create_graph=True)
 
         g = torch.cat([g.reshape(-1) for g in grads])
-        H = torch.empty(self.numel, self.numel)
+        H = prototype.new_empty(self.numel, self.numel)
 
         for idx in range(g.shape[0]):
             H[idx] = torch.hstack([
                 d.view(1, -1) for d in grad(g[idx], self.param_groups[0]['params'], create_graph=True, retain_graph=True)
             ])
-        H += 1e-4 * torch.eye(self.numel) # damping for num. stability
+        H += 1e-4 * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype) # damping for num. stability
 
         self.update_weights(
             torch.linalg.solve(H, -g)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from optimizers import Annealing
 from optimizers import ExtendedKalmanFilter
@@ -22,6 +23,25 @@ def test_newton_step_runs():
     optimizer = Newton([x])
 
     optimizer.step(lambda: (x ** 2).sum())
+
+
+def test_newton_step_runs_with_float64():
+    x = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.float64))
+    optimizer = Newton([x])
+
+    optimizer.step(lambda: (x ** 2).sum())
+
+
+def test_newton_rejects_multiple_param_groups():
+    x = _scalar_param()
+    y = _scalar_param(2.0)
+    optimizer = Newton([
+        {"params": [x]},
+        {"params": [y]},
+    ])
+
+    with pytest.raises(AssertionError):
+        optimizer.step(lambda: (x ** 2).sum() + (y ** 2).sum())
 
 
 def test_annealing_step_runs():
@@ -55,6 +75,15 @@ def test_genetic_step_runs_with_small_population():
 
 def test_levenberg_marquardt_step_runs():
     x = _scalar_param()
+    optimizer = LevenbergMarquardt([x])
+
+    loss = optimizer.step(lambda: x.view(-1))
+
+    assert isinstance(loss, float)
+
+
+def test_levenberg_marquardt_step_runs_with_float64():
+    x = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.float64))
     optimizer = LevenbergMarquardt([x])
 
     loss = optimizer.step(lambda: x.view(-1))


### PR DESCRIPTION
## Summary
- make `Newton` and `LevenbergMarquardt` allocate temporary tensors on the same device and dtype as the active parameters/residuals
- reject multiple parameter groups explicitly in `Newton` and cover the new behavior with focused runtime tests