### PR TITLE
fix: handle optimizer runtime edge cases

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -41,7 +41,7 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
     
     def loss(self, errors):
         # MSE loss, not divided by number of data, doesn't matter
-        return errors.T @ errors
+        return errors @ errors
     
     @torch.no_grad()
     def update_weights(self, updates):

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -53,6 +53,9 @@ class Genetic(torch.optim.Optimizer):
 
     @torch.no_grad
     def crossover(self, parent1, parent2):
+        if self.numel < 2:
+            return parent1.clone(), parent2.clone()
+
         crossover_point = torch.randint(1, self.numel, (1,))[0]
 
         child1 = torch.cat((parent1[:crossover_point], parent2[crossover_point:]))

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -43,7 +43,7 @@ class LevenbergMarquardt(torch.optim.Optimizer):
     @torch.no_grad()
     def loss(self, errors):
         # MSE loss, not divided by number of data, doesn't matter
-        return errors.T @ errors
+        return errors @ errors
     
     @torch.no_grad()
     def update_weights(self, update):
@@ -77,10 +77,12 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         self.update_weights(updates)
 
         # line search for mu
-        for m in range(self.m_max):
+        loss_decreased = False
+        for _ in range(self.m_max):
 
             # check if loss has decreased
             if self.loss(closure()) < self.loss(errors):
+                loss_decreased = True
                 break
 
             # restore weights
@@ -94,7 +96,7 @@ class LevenbergMarquardt(torch.optim.Optimizer):
             # update weights
             self.update_weights(update = +updates)
 
-        if m < self.m_max:
+        if loss_decreased:
             self.mu /= self.mu_factor
 
         # how to return break?, should I return loss?

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -73,6 +73,17 @@ def test_genetic_step_runs_with_small_population():
     assert isinstance(loss, torch.Tensor)
 
 
+def test_genetic_step_runs_with_scalar_parameter_vector():
+    x = _scalar_param()
+    optimizer = Genetic([x])
+    optimizer.pop_size = 4
+    optimizer.population = optimizer.params.unsqueeze(0).repeat(optimizer.pop_size, 1)
+
+    loss = optimizer.step(lambda: (x ** 2).sum())
+
+    assert isinstance(loss, torch.Tensor)
+
+
 def test_levenberg_marquardt_step_runs():
     x = _scalar_param()
     optimizer = LevenbergMarquardt([x])
@@ -85,6 +96,15 @@ def test_levenberg_marquardt_step_runs():
 def test_levenberg_marquardt_step_runs_with_float64():
     x = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.float64))
     optimizer = LevenbergMarquardt([x])
+
+    loss = optimizer.step(lambda: x.view(-1))
+
+    assert isinstance(loss, float)
+
+
+def test_levenberg_marquardt_step_runs_with_zero_line_search_steps():
+    x = _scalar_param()
+    optimizer = LevenbergMarquardt([x], m_max=0)
 
     loss = optimizer.step(lambda: x.view(-1))
 


### PR DESCRIPTION
## Summary
- make `Genetic` handle scalar parameter vectors without crashing during crossover
- make `LevenbergMarquardt` handle `m_max=0` and replace deprecated 1D residual loss expressions in the residual-based optimizers
- add focused runtime regression tests for the new edge cases