### PR TITLE
fix: handle unused Newton parameters

### DIFF
--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -33,14 +33,26 @@ class Newton(torch.optim.Optimizer):
 
         prototype = self.param_groups[0]['params'][0]
 
-        grads = grad(closure(), self.param_groups[0]['params'], create_graph=True)
+        params = self.param_groups[0]['params']
+        grads = grad(closure(), params, create_graph=True, allow_unused=True)
 
-        g = torch.cat([g.reshape(-1) for g in grads])
+        g = torch.cat([
+            g.reshape(-1) if g is not None else param.new_zeros(param.numel())
+            for param, g in zip(params, grads)
+        ])
         H = prototype.new_empty(self.numel, self.numel)
 
         for idx in range(g.shape[0]):
+            if not g[idx].requires_grad:
+                H[idx] = prototype.new_zeros(self.numel)
+                continue
+
             H[idx] = torch.hstack([
-                d.view(1, -1) for d in grad(g[idx], self.param_groups[0]['params'], create_graph=True, retain_graph=True)
+                d.view(1, -1) if d is not None else param.new_zeros(1, param.numel())
+                for param, d in zip(
+                    params,
+                    grad(g[idx], params, create_graph=True, retain_graph=True, allow_unused=True)
+                )
             ])
         H += 1e-4 * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype) # damping for num. stability
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -44,6 +44,17 @@ def test_newton_rejects_multiple_param_groups():
         optimizer.step(lambda: (x ** 2).sum() + (y ** 2).sum())
 
 
+def test_newton_step_ignores_unused_trainable_parameter():
+    x = _scalar_param()
+    y = _scalar_param(2.0)
+    optimizer = Newton([x, y])
+
+    optimizer.step(lambda: (x ** 2).sum())
+
+    assert x.item() != 1.0
+    assert y.item() == pytest.approx(2.0)
+
+
 def test_annealing_step_runs():
     x = _scalar_param()
     optimizer = Annealing([x])


### PR DESCRIPTION
## Summary
- let `Newton.step()` treat trainable parameters that are unused by the closure as zero-gradient, zero-Hessian entries
- add a regression test for the reproduced unused-parameter failure from issue #25

Closes #25.