### PR TITLE
fix: ignore frozen parameters in second-order optimizers

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -19,21 +19,27 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
 
         self.numel = sum(param.numel() for group in self.param_groups for param in group['params'] if param.requires_grad)
 
-        prototype = self.param_groups[0]['params'][0]
+        if self.numel == 0:
+            raise ValueError("ExtendedKalmanFilter requires at least one trainable parameter")
+
+        prototype = next(
+            param for group in self.param_groups for param in group['params'] if param.requires_grad
+        )
 
         self.P = torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
         self.Q = self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
 
     def jacobian(self, targets):
         # needs to be tested (nn design)
+        params = [param for param in self.param_groups[0]['params'] if param.requires_grad]
         J = targets.new_empty(targets.shape[0], self.numel)
         
         for i in range(targets.shape[0]):
             J[i] = torch.hstack([
                 d.view(1, -1) if d is not None else param.new_zeros(1, param.numel())
                 for param, d in zip(
-                    self.param_groups[0]['params'],
-                    grad(targets[i], self.param_groups[0]['params'], create_graph=True, retain_graph=True, allow_unused=True)
+                    params,
+                    grad(targets[i], params, create_graph=True, retain_graph=True, allow_unused=True)
                 )
             ])
 
@@ -50,6 +56,9 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
         start_idx = 0
         for group in self.param_groups:
             for param in group['params']:
+                if not param.requires_grad:
+                    continue
+
                 param.data.add_(updates[start_idx:start_idx + param.numel()].view(param.size()))
                 start_idx += param.numel()
 

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -18,7 +18,12 @@ class KalmanFilter(torch.optim.Optimizer):
 
         self.numel = sum(param.numel() for group in self.param_groups for param in group['params'] if param.requires_grad)
 
-        prototype = self.param_groups[0]['params'][0]
+        if self.numel == 0:
+            raise ValueError("KalmanFilter requires at least one trainable parameter")
+
+        prototype = next(
+            param for group in self.param_groups for param in group['params'] if param.requires_grad
+        )
 
         self.P = torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
         self.Q = self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
@@ -34,6 +39,9 @@ class KalmanFilter(torch.optim.Optimizer):
         start_idx = 0
         for group in self.param_groups:
             for param in group['params']:
+                if not param.requires_grad:
+                    continue
+
                 param.data.add_(updates[start_idx:start_idx + param.numel()].view(param.size()))
                 start_idx += param.numel()
 

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -22,19 +22,25 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         self.numel = sum(param.numel() for group in self.param_groups for param in group['params'] if param.requires_grad)
         # self.numel = reduce(lambda total, p: total + p.numel(), self.param_groups, 0)
 
-        self.prototype = self.param_groups[0]['params'][0]
+        if self.numel == 0:
+            raise ValueError("LevenbergMarquardt requires at least one trainable parameter")
+
+        self.prototype = next(
+            param for group in self.param_groups for param in group['params'] if param.requires_grad
+        )
 
     # @torch.compile ?
     def jacobian(self, targets):
         # needs to be tested (nn design)
+        params = [param for param in self.param_groups[0]['params'] if param.requires_grad]
         J = targets.new_empty(targets.shape[0], self.numel)
         
         for i in range(targets.shape[0]):
             J[i] = torch.hstack([
                 d.view(1, -1) if d is not None else param.new_zeros(1, param.numel())
                 for param, d in zip(
-                    self.param_groups[0]['params'],
-                    grad(targets[i], self.param_groups[0]['params'], create_graph=True, retain_graph=True, allow_unused=True)
+                    params,
+                    grad(targets[i], params, create_graph=True, retain_graph=True, allow_unused=True)
                 )
             ])
 
@@ -52,6 +58,9 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         offset = 0
         for group in self.param_groups:
             for param in group['params']:
+                if not param.requires_grad:
+                    continue
+
                 numel = param.numel()
 
                 param.add_(update[offset: offset + numel].view_as(param))

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -7,8 +7,11 @@ class Newton(torch.optim.Optimizer):
         super().__init__(params, {})
 
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            p.numel() for group in self.param_groups for p in group['params'] if p.requires_grad
         )
+
+        if self.numel == 0:
+            raise ValueError("Newton requires at least one trainable parameter")
     
     @property
     def params(self):
@@ -23,6 +26,9 @@ class Newton(torch.optim.Optimizer):
         offset = 0
         for group in self.param_groups:
             for param in group['params']:
+                if not param.requires_grad:
+                    continue
+
                 numel = param.numel()
 
                 param.add_(update[offset: offset + numel].view_as(param))
@@ -31,9 +37,8 @@ class Newton(torch.optim.Optimizer):
     def step(self, closure: callable):
         assert len(self.param_groups) == 1
 
-        prototype = self.param_groups[0]['params'][0]
-
-        params = self.param_groups[0]['params']
+        params = [param for param in self.param_groups[0]['params'] if param.requires_grad]
+        prototype = params[0]
         grads = grad(closure(), params, create_graph=True, allow_unused=True)
 
         g = torch.cat([

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -55,6 +55,17 @@ def test_newton_step_ignores_unused_trainable_parameter():
     assert y.item() == pytest.approx(2.0)
 
 
+def test_newton_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = Newton([x, y])
+
+    optimizer.step(lambda: (y ** 2).sum())
+
+    assert x.item() == pytest.approx(2.0)
+    assert y.item() != 1.0
+
+
 def test_annealing_step_runs():
     x = _scalar_param()
     optimizer = Annealing([x])
@@ -122,6 +133,17 @@ def test_levenberg_marquardt_step_runs_with_zero_line_search_steps():
     assert isinstance(loss, float)
 
 
+def test_levenberg_marquardt_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = LevenbergMarquardt([x, y])
+
+    loss = optimizer.step(lambda: y.view(-1))
+
+    assert isinstance(loss, float)
+    assert x.item() == pytest.approx(2.0)
+
+
 def test_extended_kalman_filter_step_runs():
     x = _scalar_param()
     optimizer = ExtendedKalmanFilter([x])
@@ -129,6 +151,17 @@ def test_extended_kalman_filter_step_runs():
     loss = optimizer.step(lambda: x.view(-1))
 
     assert isinstance(loss, torch.Tensor)
+
+
+def test_extended_kalman_filter_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = ExtendedKalmanFilter([x, y])
+
+    loss = optimizer.step(lambda: y.view(-1))
+
+    assert isinstance(loss, torch.Tensor)
+    assert x.item() == pytest.approx(2.0)
 
 
 def test_kalman_filter_step_runs():
@@ -143,3 +176,19 @@ def test_kalman_filter_step_runs():
     loss = optimizer.step(closure)
 
     assert isinstance(loss, torch.Tensor)
+
+
+def test_kalman_filter_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = KalmanFilter([x, y])
+
+    def closure():
+        errors = y.view(-1)
+        H = torch.eye(1, device=y.device, dtype=y.dtype)
+        return errors, H
+
+    loss = optimizer.step(closure)
+
+    assert isinstance(loss, torch.Tensor)
+    assert x.item() == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- make the second-order optimizers consistently operate on trainable parameters only
- reject the degenerate case where no trainable parameters are provided
- add regression coverage for the reproduced frozen-parameter failures from issue #26

Closes #26.