### PR TITLE
fix: restore LM weights after rejected search

### DIFF
--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -76,6 +76,7 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         # errors need to be computed from closure
         # closure (callable) - reevaluates the model and returns the loss, in our case the errors
         errors = closure()
+        base_loss = self.loss(errors)
         
         # compute Jacobian matrix
         J = self.jacobian(errors)
@@ -86,12 +87,9 @@ class LevenbergMarquardt(torch.optim.Optimizer):
         self.update_weights(updates)
 
         # line search for mu
-        loss_decreased = False
+        loss_decreased = self.loss(closure()) < base_loss
         for _ in range(self.m_max):
-
-            # check if loss has decreased
-            if self.loss(closure()) < self.loss(errors):
-                loss_decreased = True
+            if loss_decreased:
                 break
 
             # restore weights
@@ -105,8 +103,12 @@ class LevenbergMarquardt(torch.optim.Optimizer):
             # update weights
             self.update_weights(update = +updates)
 
+            loss_decreased = self.loss(closure()) < base_loss
+
         if loss_decreased:
             self.mu /= self.mu_factor
+        else:
+            self.update_weights(update = -updates)
 
         # how to return break?, should I return loss?
         # -> returning loss, mu can be controled by

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -144,6 +144,21 @@ def test_levenberg_marquardt_step_ignores_frozen_parameter():
     assert x.item() == pytest.approx(2.0)
 
 
+def test_levenberg_marquardt_restores_weights_when_line_search_fails():
+    x = torch.nn.Parameter(torch.tensor([-2.9], dtype=torch.float64))
+    optimizer = LevenbergMarquardt([x], mu=1e-6, m_max=1)
+
+    def closure():
+        return torch.sin(5 * x).view(-1)
+
+    before = (closure() @ closure()).item()
+    optimizer.step(closure)
+    after = (closure() @ closure()).item()
+
+    assert after == pytest.approx(before)
+    assert x.item() == pytest.approx(-2.9)
+
+
 def test_extended_kalman_filter_step_runs():
     x = _scalar_param()
     optimizer = ExtendedKalmanFilter([x])


### PR DESCRIPTION
## Summary
- make `LevenbergMarquardt.step()` restore the original weights when all damped trial steps are rejected
- add a regression test for the reproduced rejected-step failure from issue #27

Closes #27.