### PR TITLE
fix: use explicit stochastic acceptance index

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -43,9 +43,9 @@ class Annealing(torch.optim.Optimizer):
             self.update_weights(params)
             Fs[idx] = closure().item()
 
-        idx = torch.rand(1) < torch.exp(
+        idx = int((torch.rand(1) < torch.exp(
             (Fs[0] - Fs[1]) / self.temperature
-        )
+        )).item())
 
         self.update_weights(variants[idx])
         self.temperature *= 1 - 1e-3

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -45,9 +45,9 @@ class Metropolis(torch.optim.Optimizer):
             self.update_weights(params)
             Fs[idx] = closure().item()
 
-        idx = torch.rand(1) < torch.exp(
+        idx = int((torch.rand(1) < torch.exp(
             (Fs[0] - Fs[1]) / self.temperature
-        )
+        )).item())
 
         self.update_weights(variants[idx])
         self.temperature *= 1 - 1e-3

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -62,6 +62,26 @@ def test_metropolis_step_runs():
     assert isinstance(loss, torch.Tensor)
 
 
+@pytest.mark.parametrize("optimizer_cls", [Annealing, Metropolis])
+def test_stochastic_step_acceptance_uses_explicit_index(optimizer_cls, monkeypatch):
+    x = _scalar_param()
+    optimizer = optimizer_cls([x])
+
+    def closure():
+        return (x ** 2).sum()
+
+    monkeypatch.setattr(optimizer, "mutate", lambda: torch.tensor([2.0]))
+
+    monkeypatch.setattr(torch, "rand", lambda *args, **kwargs: torch.tensor([0.0]))
+    optimizer.step(closure)
+    assert x.item() == pytest.approx(2.0)
+
+    optimizer.update_weights(torch.tensor([1.0]))
+    monkeypatch.setattr(torch, "rand", lambda *args, **kwargs: torch.tensor([1.0]))
+    optimizer.step(closure)
+    assert x.item() == pytest.approx(1.0)
+
+
 def test_genetic_step_runs_with_small_population():
     x = _vector_param()
     optimizer = Genetic([x])


### PR DESCRIPTION
## Summary
- make the annealing/metropolis acceptance path use an explicit integer index instead of relying on tensor coercion for list indexing
- add deterministic accept/reject regression coverage for both optimizers

Closes #23.