### PR TITLE
fix: localize Metropolis mutation proposals

### DIFF
--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -30,11 +30,11 @@ class Metropolis(torch.optim.Optimizer):
 
     @torch.no_grad
     def mutate(self, ):
-        torch.randint(low=0, high=self.numel, size=(1,))
-        
-        return self.params + torch.randn_like(
-            self.params
-        )*self.temperature
+        proposal = self.params.clone()
+        idx = torch.randint(low=0, high=self.numel, size=()).item()
+        proposal[idx] += torch.randn((), device=proposal.device, dtype=proposal.dtype) * self.temperature
+
+        return proposal
 
     @torch.no_grad
     def step(self, closure):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -62,6 +62,17 @@ def test_metropolis_step_runs():
     assert isinstance(loss, torch.Tensor)
 
 
+def test_metropolis_mutate_changes_single_parameter():
+    x = torch.nn.Parameter(torch.tensor([1.0, -1.0, 0.5]))
+    optimizer = Metropolis([x])
+
+    torch.manual_seed(0)
+    before = optimizer.params.clone()
+    after = optimizer.mutate()
+
+    assert torch.count_nonzero(after - before).item() == 1
+
+
 def test_genetic_step_runs_with_small_population():
     x = _vector_param()
     optimizer = Genetic([x])


### PR DESCRIPTION
## Summary
- make `Metropolis.mutate()` use the sampled index and perturb exactly one flattened parameter
- add regression coverage to verify the proposal changes a single coordinate

Closes #24.