### PR TITLE
refactor: share flattened-parameter optimizer backend

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -1,32 +1,17 @@
 import torch
 
+from ._utils import _FlatParamOptimizerMixin
+from ._utils import all_params
 
-class Annealing(torch.optim.Optimizer):
+
+class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, {}) 
 
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            param.numel() for param in all_params(self.param_groups)
         )
         self.temperature = 1
-
-    @property
-    def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
-
-    @torch.no_grad
-    def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
 
     @torch.no_grad
     def mutate(self):

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,8 +1,10 @@
 import torch
 from .Newton import Newton
+from ._utils import _FlatParamOptimizerMixin
+from ._utils import all_params
 
 
-class Genetic(torch.optim.Optimizer):
+class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, {}) 
 
@@ -14,7 +16,7 @@ class Genetic(torch.optim.Optimizer):
         self.best_fitness = float('inf')
 
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            param.numel() for param in all_params(self.param_groups)
         )
         self.pop_size = 100 # max(int(self.numel**0.5), 10)
 
@@ -23,24 +25,6 @@ class Genetic(torch.optim.Optimizer):
 
         self.helper = torch.optim.Adam(self.param_groups)
         # self.helper = Newton(self.param_groups[0]['params'])
-
-    @property
-    def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
-
-    @torch.no_grad
-    def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
 
     @torch.no_grad
     def mutate(self, genome):

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -1,32 +1,17 @@
 import torch
 
+from ._utils import _FlatParamOptimizerMixin
+from ._utils import all_params
 
-class Metropolis(torch.optim.Optimizer):
+
+class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, {}) 
 
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            param.numel() for param in all_params(self.param_groups)
         )
         self.temperature = 10
-
-    @property
-    def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
-
-    @torch.no_grad
-    def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
 
     @torch.no_grad
     def mutate(self, ):

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -2,6 +2,14 @@ import torch
 from torch.autograd import grad
 
 
+def all_params(param_groups):
+    return [
+        param
+        for group in param_groups
+        for param in group['params']
+    ]
+
+
 def trainable_params(param_groups):
     return [
         param
@@ -9,6 +17,25 @@ def trainable_params(param_groups):
         for param in group['params']
         if param.requires_grad
     ]
+
+
+def flat_params(param_groups):
+    return torch.cat([
+        param.flatten()
+        for param in all_params(param_groups)
+    ])
+
+
+@torch.no_grad()
+def load_flat_params_(params, values):
+    values = values.view(-1)
+
+    offset = 0
+    for param in params:
+        numel = param.numel()
+
+        param.copy_(values[offset: offset + numel].view_as(param))
+        offset += numel
 
 
 @torch.no_grad()
@@ -41,3 +68,13 @@ def residual_jacobian(targets, params):
 
 def residual_sum_squares(errors):
     return errors @ errors
+
+
+class _FlatParamOptimizerMixin:
+    @property
+    def params(self):
+        return flat_params(self.param_groups)
+
+    @torch.no_grad()
+    def update_weights(self, update):
+        load_flat_params_(all_params(self.param_groups), update)


### PR DESCRIPTION
## Summary
- extract shared flattened-parameter helper functions into `_utils.py`
- add a private `_FlatParamOptimizerMixin` for the common `params` and `update_weights()` behavior used by `Annealing`, `Metropolis`, and `Genetic`
- keep each optimizer's `step()` logic unchanged while removing the duplicated flatten/load implementations

Related follow-up bug: #35 tracks frozen-parameter handling for these optimizers.