### PR TITLE
fix: keep frozen params unchanged in search optimizers

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -1,32 +1,31 @@
 import torch
 
+from ._utils import flat_params
+from ._utils import load_flat_params_
+from ._utils import trainable_params
+
 
 class Annealing(torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, {}) 
 
+        params = trainable_params(self.param_groups)
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            param.numel() for param in params
         )
+
+        if self.numel == 0:
+            raise ValueError("Annealing requires at least one trainable parameter")
+
         self.temperature = 1
 
     @property
     def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
+        return flat_params(trainable_params(self.param_groups))
 
     @torch.no_grad
     def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
+        load_flat_params_(trainable_params(self.param_groups), update)
 
     @torch.no_grad
     def mutate(self):

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,5 +1,8 @@
 import torch
 from .Newton import Newton
+from ._utils import flat_params
+from ._utils import load_flat_params_
+from ._utils import trainable_params
 
 
 class Genetic(torch.optim.Optimizer):
@@ -10,13 +13,18 @@ class Genetic(torch.optim.Optimizer):
         self.mutation_strength = 0.1
         self.elite_ratio = 0.2
 
+        params = trainable_params(self.param_groups)
+        self.numel = sum(
+            param.numel() for param in params
+        )
+
+        if self.numel == 0:
+            raise ValueError("Genetic requires at least one trainable parameter")
+
+        self.pop_size = 100 # max(int(self.numel**0.5), 10)
+
         self.best_genome = self.params
         self.best_fitness = float('inf')
-
-        self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
-        )
-        self.pop_size = 100 # max(int(self.numel**0.5), 10)
 
         self.population = self.params.unsqueeze(0).repeat(self.pop_size, 1)
         self.population += torch.randn_like(self.population) * 1e-0
@@ -26,21 +34,11 @@ class Genetic(torch.optim.Optimizer):
 
     @property
     def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
+        return flat_params(trainable_params(self.param_groups))
 
     @torch.no_grad
     def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
+        load_flat_params_(trainable_params(self.param_groups), update)
 
     @torch.no_grad
     def mutate(self, genome):

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -1,32 +1,31 @@
 import torch
 
+from ._utils import flat_params
+from ._utils import load_flat_params_
+from ._utils import trainable_params
+
 
 class Metropolis(torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, {}) 
 
+        params = trainable_params(self.param_groups)
         self.numel = sum(
-            p.numel() for group in self.param_groups for p in group['params']
+            param.numel() for param in params
         )
+
+        if self.numel == 0:
+            raise ValueError("Metropolis requires at least one trainable parameter")
+
         self.temperature = 10
 
     @property
     def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
+        return flat_params(trainable_params(self.param_groups))
 
     @torch.no_grad
     def update_weights(self, update):
-        update = update.flatten()
-
-        offset = 0
-        for group in self.param_groups:
-            for param in group['params']:
-                numel = param.numel()
-
-                param.data = update[offset: offset + numel].view_as(param)
-                offset += numel
+        load_flat_params_(trainable_params(self.param_groups), update)
 
     @torch.no_grad
     def mutate(self, ):

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -11,6 +11,22 @@ def trainable_params(param_groups):
     ]
 
 
+def flat_params(params):
+    return torch.cat([param.flatten() for param in params])
+
+
+@torch.no_grad()
+def load_flat_params_(params, values):
+    values = values.view(-1)
+
+    offset = 0
+    for param in params:
+        numel = param.numel()
+
+        param.copy_(values[offset: offset + numel].view_as(param))
+        offset += numel
+
+
 @torch.no_grad()
 def add_flat_update_(params, update):
     update = update.view(-1)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -115,6 +115,43 @@ def test_metropolis_mutate_changes_single_parameter():
     assert torch.count_nonzero(after - before).item() == 1
 
 
+def test_annealing_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = Annealing([x, y])
+
+    optimizer.step(lambda: (y ** 2).sum())
+
+    assert x.item() == pytest.approx(2.0)
+
+
+def test_metropolis_step_ignores_frozen_parameter(monkeypatch):
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = Metropolis([x, y])
+
+    monkeypatch.setattr(optimizer, "mutate", lambda: torch.tensor([0.0]))
+    monkeypatch.setattr(torch, "rand", lambda *args, **kwargs: torch.tensor([0.0]))
+
+    optimizer.step(lambda: (y ** 2).sum())
+
+    assert x.item() == pytest.approx(2.0)
+    assert y.item() == pytest.approx(0.0)
+
+
+def test_genetic_step_ignores_frozen_parameter():
+    x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    y = _scalar_param()
+    optimizer = Genetic([x, y])
+    optimizer.pop_size = 4
+    optimizer.population = torch.tensor([[0.0]]).repeat(optimizer.pop_size, 1)
+
+    optimizer.step(lambda: (y ** 2).sum())
+
+    assert x.item() == pytest.approx(2.0)
+    assert y.item() == pytest.approx(0.0)
+
+
 def test_genetic_step_runs_with_small_population():
     x = _vector_param()
     optimizer = Genetic([x])


### PR DESCRIPTION
## Summary
- make `Annealing`, `Metropolis`, and `Genetic` operate only on trainable parameters when flattening and reloading optimizer state
- reject the degenerate case where no trainable parameters are provided
- add regression coverage to ensure frozen parameters stay unchanged during optimizer steps

Closes #35.