### PR TITLE
fix: restore trainable-only flat optimizer state

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -2,6 +2,7 @@ import torch
 
 from ._utils import _FlatParamOptimizerMixin
 from ._utils import all_params
+from ._utils import trainable_params
 
 
 class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
@@ -9,9 +10,7 @@ class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         super().__init__(params, {}) 
 
         params = trainable_params(self.param_groups)
-        self.numel = sum(
-            param.numel() for param in all_params(self.param_groups)
-        )
+        self.numel = sum(param.numel() for param in params)
 
         if self.numel == 0:
             raise ValueError("Annealing requires at least one trainable parameter")

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -2,6 +2,7 @@ import torch
 from .Newton import Newton
 from ._utils import _FlatParamOptimizerMixin
 from ._utils import all_params
+from ._utils import trainable_params
 
 
 class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
@@ -13,9 +14,7 @@ class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         self.elite_ratio = 0.2
 
         params = trainable_params(self.param_groups)
-        self.numel = sum(
-            param.numel() for param in all_params(self.param_groups)
-        )
+        self.numel = sum(param.numel() for param in params)
 
         if self.numel == 0:
             raise ValueError("Genetic requires at least one trainable parameter")

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -2,6 +2,7 @@ import torch
 
 from ._utils import _FlatParamOptimizerMixin
 from ._utils import all_params
+from ._utils import trainable_params
 
 
 class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
@@ -9,9 +10,7 @@ class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         super().__init__(params, {}) 
 
         params = trainable_params(self.param_groups)
-        self.numel = sum(
-            param.numel() for param in all_params(self.param_groups)
-        )
+        self.numel = sum(param.numel() for param in params)
 
         if self.numel == 0:
             raise ValueError("Metropolis requires at least one trainable parameter")

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -19,10 +19,10 @@ def trainable_params(param_groups):
     ]
 
 
-def flat_params(param_groups):
+def flat_params(params):
     return torch.cat([
         param.flatten()
-        for param in all_params(param_groups)
+        for param in params
     ])
 
 
@@ -73,8 +73,8 @@ def residual_sum_squares(errors):
 class _FlatParamOptimizerMixin:
     @property
     def params(self):
-        return flat_params(self.param_groups)
+        return flat_params(trainable_params(self.param_groups))
 
     @torch.no_grad()
     def update_weights(self, update):
-        load_flat_params_(all_params(self.param_groups), update)
+        load_flat_params_(trainable_params(self.param_groups), update)


### PR DESCRIPTION
## Summary
- fix the flattened-parameter optimizer helpers so they operate on trainable parameters only
- restore the intended frozen-parameter behavior for `Annealing`, `Metropolis`, and `Genetic`
- repair the helper wiring that left `main` failing CI after PR #37 merged

Closes #35.