### PR TITLE
fix: persist Kalman optimizer runtime state

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -10,13 +10,11 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
     # only one parameter group can be used!
     # add @property q(t)
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
-        self.eta, self.eps, self.q, self.tau = eta, eps, q, tau
-
         defaults = dict(
-                    eta = self.eta,
-                    eps = self.eps,
-                    q = self.q,
-                    tau = self.tau
+                    eta = eta,
+                    eps = eps,
+                    q = q,
+                    tau = tau
                 )
         
         super(ExtendedKalmanFilter, self).__init__(params, defaults)
@@ -27,10 +25,56 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
         if self.numel == 0:
             raise ValueError("ExtendedKalmanFilter requires at least one trainable parameter")
 
-        prototype = params[0]
+        self.state[params[0]]['P'] = torch.eye(
+            self.numel,
+            device=params[0].device,
+            dtype=params[0].dtype,
+        )
 
-        self.P = torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
-        self.Q = self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
+    @property
+    def eta(self):
+        return self.param_groups[0]['eta']
+
+    @eta.setter
+    def eta(self, value):
+        self.param_groups[0]['eta'] = value
+
+    @property
+    def eps(self):
+        return self.param_groups[0]['eps']
+
+    @eps.setter
+    def eps(self, value):
+        self.param_groups[0]['eps'] = value
+
+    @property
+    def q(self):
+        return self.param_groups[0]['q']
+
+    @q.setter
+    def q(self, value):
+        self.param_groups[0]['q'] = value
+
+    @property
+    def tau(self):
+        return self.param_groups[0]['tau']
+
+    @tau.setter
+    def tau(self, value):
+        self.param_groups[0]['tau'] = value
+
+    @property
+    def P(self):
+        return self.state[trainable_params(self.param_groups)[0]]['P']
+
+    @P.setter
+    def P(self, value):
+        self.state[trainable_params(self.param_groups)[0]]['P'] = value
+
+    @property
+    def Q(self):
+        prototype = trainable_params(self.param_groups)[0]
+        return self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
 
     def jacobian(self, targets):
         return residual_jacobian(targets, trainable_params(self.param_groups))

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -9,13 +9,11 @@ class KalmanFilter(torch.optim.Optimizer):
     # only one parameter group can be used!
     # closure() returns (errors, H)
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
-        self.eta, self.eps, self.q, self.tau = eta, eps, q, tau
-
         defaults = dict(
-                    eta = self.eta,
-                    eps = self.eps,
-                    q = self.q,
-                    tau = self.tau
+                    eta = eta,
+                    eps = eps,
+                    q = q,
+                    tau = tau
                 )
         
         super(KalmanFilter, self).__init__(params, defaults)
@@ -26,10 +24,56 @@ class KalmanFilter(torch.optim.Optimizer):
         if self.numel == 0:
             raise ValueError("KalmanFilter requires at least one trainable parameter")
 
-        prototype = params[0]
+        self.state[params[0]]['P'] = torch.eye(
+            self.numel,
+            device=params[0].device,
+            dtype=params[0].dtype,
+        )
 
-        self.P = torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
-        self.Q = self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
+    @property
+    def eta(self):
+        return self.param_groups[0]['eta']
+
+    @eta.setter
+    def eta(self, value):
+        self.param_groups[0]['eta'] = value
+
+    @property
+    def eps(self):
+        return self.param_groups[0]['eps']
+
+    @eps.setter
+    def eps(self, value):
+        self.param_groups[0]['eps'] = value
+
+    @property
+    def q(self):
+        return self.param_groups[0]['q']
+
+    @q.setter
+    def q(self, value):
+        self.param_groups[0]['q'] = value
+
+    @property
+    def tau(self):
+        return self.param_groups[0]['tau']
+
+    @tau.setter
+    def tau(self, value):
+        self.param_groups[0]['tau'] = value
+
+    @property
+    def P(self):
+        return self.state[trainable_params(self.param_groups)[0]]['P']
+
+    @P.setter
+    def P(self, value):
+        self.state[trainable_params(self.param_groups)[0]]['P'] = value
+
+    @property
+    def Q(self):
+        prototype = trainable_params(self.param_groups)[0]
+        return self.q * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
 
     def loss(self, errors):
         return residual_sum_squares(errors)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -247,6 +247,29 @@ def test_extended_kalman_filter_step_ignores_frozen_parameter():
     assert x.item() == pytest.approx(2.0)
 
 
+def test_extended_kalman_filter_state_dict_restores_covariance():
+    x = _scalar_param()
+    optimizer = ExtendedKalmanFilter([x])
+    optimizer.step(lambda: x.view(-1))
+
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = ExtendedKalmanFilter([y])
+    restored.load_state_dict(state_dict)
+
+    assert torch.equal(optimizer.P, restored.P)
+
+
+def test_extended_kalman_filter_q_update_changes_Q():
+    x = _scalar_param()
+    optimizer = ExtendedKalmanFilter([x], q=1.0)
+
+    optimizer.q = 5.0
+
+    assert optimizer.Q[0, 0].item() == pytest.approx(5.0)
+
+
 def test_kalman_filter_step_runs():
     x = _scalar_param()
     optimizer = KalmanFilter([x])
@@ -275,3 +298,29 @@ def test_kalman_filter_step_ignores_frozen_parameter():
 
     assert isinstance(loss, torch.Tensor)
     assert x.item() == pytest.approx(2.0)
+
+
+def test_kalman_filter_state_dict_restores_covariance():
+    x = _scalar_param()
+    optimizer = KalmanFilter([x])
+
+    def closure():
+        return x.view(-1), torch.eye(1, device=x.device, dtype=x.dtype)
+
+    optimizer.step(closure)
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = KalmanFilter([y])
+    restored.load_state_dict(state_dict)
+
+    assert torch.equal(optimizer.P, restored.P)
+
+
+def test_kalman_filter_q_update_changes_Q():
+    x = _scalar_param()
+    optimizer = KalmanFilter([x], q=1.0)
+
+    optimizer.q = 5.0
+
+    assert optimizer.Q[0, 0].item() == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- store Kalman covariance state in `Optimizer.state` so checkpoint/resume restores it correctly
- make `q` a live param-group-backed hyperparameter so updating `optimizer.q` affects subsequent steps
- add regression tests for covariance restoration and live `q` updates in both `ExtendedKalmanFilter` and `KalmanFilter`

Closes #39.
Part of #40.