### PR TITLE
fix: persist LM damping state

### DIFF
--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -12,13 +12,9 @@ class LevenbergMarquardt(torch.optim.Optimizer):
     # update defaults
     # add loss history; batches can be controled from closure()
     def __init__(self, params, mu = 10**3, mu_factor = 5, m_max = 10):
-        self.mu = mu
-        self.mu_factor = mu_factor
-        self.m_max = m_max
-
-        defaults = dict(mu = self.mu,
-                        mu_factor = self.mu_factor,
-                        m_max = self.m_max
+        defaults = dict(mu = mu,
+                        mu_factor = mu_factor,
+                        m_max = m_max
                     )
         
         super(LevenbergMarquardt, self).__init__(params, defaults)
@@ -31,6 +27,30 @@ class LevenbergMarquardt(torch.optim.Optimizer):
             raise ValueError("LevenbergMarquardt requires at least one trainable parameter")
 
         self.prototype = params[0]
+
+    @property
+    def mu(self):
+        return self.param_groups[0]['mu']
+
+    @mu.setter
+    def mu(self, value):
+        self.param_groups[0]['mu'] = value
+
+    @property
+    def mu_factor(self):
+        return self.param_groups[0]['mu_factor']
+
+    @mu_factor.setter
+    def mu_factor(self, value):
+        self.param_groups[0]['mu_factor'] = value
+
+    @property
+    def m_max(self):
+        return self.param_groups[0]['m_max']
+
+    @m_max.setter
+    def m_max(self, value):
+        self.param_groups[0]['m_max'] = value
 
     # @torch.compile ?
     def jacobian(self, targets):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -227,6 +227,21 @@ def test_levenberg_marquardt_restores_weights_when_line_search_fails():
     assert x.item() == pytest.approx(-2.9)
 
 
+def test_levenberg_marquardt_state_dict_restores_mu():
+    x = _scalar_param()
+    optimizer = LevenbergMarquardt([x], mu=1.0, mu_factor=10, m_max=1)
+
+    optimizer.step(lambda: torch.tensor([10.0]) * x.view(-1))
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = LevenbergMarquardt([y], mu=99.0, mu_factor=2, m_max=3)
+    restored.load_state_dict(state_dict)
+
+    assert state_dict['param_groups'][0]['mu'] == pytest.approx(optimizer.mu)
+    assert restored.mu == pytest.approx(optimizer.mu)
+
+
 def test_extended_kalman_filter_step_runs():
     x = _scalar_param()
     optimizer = ExtendedKalmanFilter([x])


### PR DESCRIPTION
## Summary
- make `LevenbergMarquardt` keep `mu` in the serialized param-group state so checkpoint/resume preserves adaptive damping
- expose `mu`, `mu_factor`, and `m_max` as param-group-backed properties
- add regression coverage for `state_dict()` / `load_state_dict()` restoration of `mu`

Part of #40.