### PR TITLE
fix: persist search optimizer temperature

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -7,7 +7,7 @@ from ._utils import trainable_params
 
 class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     def __init__(self, params):
-        super().__init__(params, {}) 
+        super().__init__(params, dict(temperature=1.0)) 
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
@@ -15,7 +15,13 @@ class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         if self.numel == 0:
             raise ValueError("Annealing requires at least one trainable parameter")
 
-        self.temperature = 1
+    @property
+    def temperature(self):
+        return self.param_groups[0]['temperature']
+
+    @temperature.setter
+    def temperature(self, value):
+        self.param_groups[0]['temperature'] = value
 
     @torch.no_grad
     def mutate(self):

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -7,7 +7,7 @@ from ._utils import trainable_params
 
 class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     def __init__(self, params):
-        super().__init__(params, {}) 
+        super().__init__(params, dict(temperature=10.0)) 
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
@@ -15,7 +15,13 @@ class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         if self.numel == 0:
             raise ValueError("Metropolis requires at least one trainable parameter")
 
-        self.temperature = 10
+    @property
+    def temperature(self):
+        return self.param_groups[0]['temperature']
+
+    @temperature.setter
+    def temperature(self, value):
+        self.param_groups[0]['temperature'] = value
 
     @torch.no_grad
     def mutate(self, ):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -125,6 +125,21 @@ def test_annealing_step_ignores_frozen_parameter():
     assert x.item() == pytest.approx(2.0)
 
 
+def test_annealing_state_dict_restores_temperature():
+    x = _scalar_param()
+    optimizer = Annealing([x])
+    optimizer.step(lambda: (x ** 2).sum())
+
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = Annealing([y])
+    restored.load_state_dict(state_dict)
+
+    assert state_dict['param_groups'][0]['temperature'] == pytest.approx(optimizer.temperature)
+    assert restored.temperature == pytest.approx(optimizer.temperature)
+
+
 def test_metropolis_step_ignores_frozen_parameter(monkeypatch):
     x = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
     y = _scalar_param()
@@ -137,6 +152,21 @@ def test_metropolis_step_ignores_frozen_parameter(monkeypatch):
 
     assert x.item() == pytest.approx(2.0)
     assert y.item() == pytest.approx(0.0)
+
+
+def test_metropolis_state_dict_restores_temperature():
+    x = _scalar_param()
+    optimizer = Metropolis([x])
+    optimizer.step(lambda: (x ** 2).sum())
+
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = Metropolis([y])
+    restored.load_state_dict(state_dict)
+
+    assert state_dict['param_groups'][0]['temperature'] == pytest.approx(optimizer.temperature)
+    assert restored.temperature == pytest.approx(optimizer.temperature)
 
 
 def test_genetic_step_ignores_frozen_parameter():


### PR DESCRIPTION
## Summary
- make `Annealing` and `Metropolis` store temperature in serialized param-group state
- restore temperature correctly across `state_dict()` / `load_state_dict()`
- add regression coverage for save/load of both search optimizers

Part of #40.