### PR TITLE
docs: replace stale optimizer TODOs

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -7,8 +7,14 @@ from ._utils import trainable_params
 
 
 class ExtendedKalmanFilter(torch.optim.Optimizer):
-    # only one parameter group can be used!
-    # add @property q(t)
+    """Extended Kalman filter optimizer for residual-vector closures.
+
+    This optimizer assumes a single parameter group and expects `closure()` to
+    return a 1D tensor of residuals. The Kalman covariance `P` is persistent
+    optimizer state, while `eta`, `eps`, `q`, and `tau` are live properties on
+    the single param group.
+    """
+
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
         defaults = dict(
                     eta = eta,
@@ -90,11 +96,8 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
 
         assert len(self.param_groups) == 1
 
-        # Make sure the closure is always called with grad enabled
         closure = torch.enable_grad()(closure)
 
-        # errors need to be computed from closure
-        # closure (callable) - reevaluates the model and returns the loss, in our case the errors
         errors = closure()
         
         H = self.jacobian(errors)

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -6,8 +6,14 @@ from ._utils import trainable_params
 
 
 class KalmanFilter(torch.optim.Optimizer):
-    # only one parameter group can be used!
-    # closure() returns (errors, H)
+    """Kalman filter optimizer for linear residual closures.
+
+    This optimizer assumes a single parameter group and expects `closure()` to
+    return `(errors, H)`, where `errors` is a residual vector and `H` is the
+    linear observation matrix. The covariance `P` is persistent optimizer
+    state, while `eta`, `eps`, `q`, and `tau` are live param-group properties.
+    """
+
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
         defaults = dict(
                     eta = eta,
@@ -86,10 +92,8 @@ class KalmanFilter(torch.optim.Optimizer):
 
         assert len(self.param_groups) == 1
 
-        # Make sure the closure is always called with grad enabled
         closure = torch.enable_grad()(closure)
 
-        # closure (callable) - reevaluates the model and returns the residuals and linear observation matrix
         errors, H = closure()
         errors = errors.view(-1)
 

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -4,13 +4,19 @@ from ._utils import add_flat_update_
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
-    
+
 
 class LevenbergMarquardt(torch.optim.Optimizer):
-    # only one parameter group can be used!
-    # need to add comments
-    # update defaults
-    # add loss history; batches can be controled from closure()
+    """Levenberg-Marquardt optimizer for residual-vector closures.
+
+    This optimizer assumes a single parameter group and expects `closure()` to
+    return a 1D tensor of residuals. The `strategy` argument selects between a
+    line-search style damping update and a trust-region gain-ratio update.
+
+    `step()` returns the final residual sum of squares as a Python float, so
+    callers can keep any loss history externally.
+    """
+
     def __init__(self, params, mu = 10**3, mu_factor = 5, m_max = 10, strategy = "line search"):
         defaults = dict(mu = mu,
                         mu_factor = mu_factor,
@@ -79,7 +85,6 @@ class LevenbergMarquardt(torch.optim.Optimizer):
     def strategy(self, value):
         self.param_groups[0]['strategy'] = self._canonical_strategy(value)
 
-    # @torch.compile ?
     def jacobian(self, targets):
         return residual_jacobian(targets, trainable_params(self.param_groups))
     
@@ -156,11 +161,8 @@ class LevenbergMarquardt(torch.optim.Optimizer):
 
         assert len(self.param_groups) == 1
 
-        # Make sure the closure is always called with grad enabled
         closure = torch.enable_grad()(closure)
 
-        # errors need to be computed from closure
-        # closure (callable) - reevaluates the model and returns the loss, in our case the errors
         errors = closure()
         base_loss = self.loss(errors)
         


### PR DESCRIPTION
## Summary
- replace stale TODO-style comments in the optimizer backends with concise class docstrings
- document the closure contracts and runtime state for `LevenbergMarquardt`, `ExtendedKalmanFilter`, and `KalmanFilter`
- remove obsolete prototype comments now that the underlying work is implemented