### PR TITLE
feat: add public line search module

### DIFF
--- a/src/optimizers/__init__.py
+++ b/src/optimizers/__init__.py
@@ -1,3 +1,4 @@
+from . import line_search
 from .Genetic import Genetic
 from .Newton import Newton
 from .Annealing import Annealing
@@ -7,6 +8,7 @@ from .KalmanFilter import KalmanFilter
 from .ExtendedKalmanFilter import ExtendedKalmanFilter
 
 __all__ = [
+    "line_search",
     "Genetic",
     "Newton",
     "Annealing",

--- a/src/optimizers/line_search.py
+++ b/src/optimizers/line_search.py
@@ -1,0 +1,95 @@
+import torch
+
+
+def _as_scalar_tensor(value, reference):
+    if isinstance(value, torch.Tensor):
+        return value.to(device=reference.device, dtype=reference.dtype).reshape(())
+
+    return reference.new_tensor(value)
+
+
+def armijo_backtracking(phi, phi0, dphi0, alpha0=1.0, c1=1e-4, shrink=0.5, max_iters=20):
+    if not 0 < c1 < 1:
+        raise ValueError("armijo_backtracking requires 0 < c1 < 1")
+
+    if not 0 < shrink < 1:
+        raise ValueError("armijo_backtracking requires 0 < shrink < 1")
+
+    if max_iters < 1:
+        raise ValueError("armijo_backtracking requires max_iters >= 1")
+
+    alpha = _as_scalar_tensor(alpha0, phi0)
+    phi_alpha = phi(alpha)
+
+    for _ in range(max_iters):
+        if bool(phi_alpha <= phi0 + c1 * alpha * dphi0):
+            return alpha, phi_alpha
+
+        alpha = alpha * shrink
+        phi_alpha = phi(alpha)
+
+    return alpha, phi_alpha
+
+
+def _strong_wolfe_zoom(phi, dphi, phi0, dphi0, alpha_lo, alpha_hi, phi_lo, c1, c2, max_iters):
+    alpha = alpha_lo
+    phi_alpha = phi_lo
+    dphi_alpha = dphi(alpha_lo)
+
+    for _ in range(max_iters):
+        alpha = 0.5 * (alpha_lo + alpha_hi)
+        phi_alpha = phi(alpha)
+
+        if bool((phi_alpha > phi0 + c1 * alpha * dphi0) or (phi_alpha >= phi_lo)):
+            alpha_hi = alpha
+            continue
+
+        dphi_alpha = dphi(alpha)
+        if bool(torch.abs(dphi_alpha) <= -c2 * dphi0):
+            return alpha, phi_alpha, dphi_alpha
+
+        if bool(dphi_alpha * (alpha_hi - alpha_lo) >= 0):
+            alpha_hi = alpha_lo
+
+        alpha_lo = alpha
+        phi_lo = phi_alpha
+
+    return alpha, phi_alpha, dphi_alpha
+
+
+def strong_wolfe(phi, dphi, phi0, dphi0, alpha0=1.0, c1=1e-4, c2=0.9, max_iters=20, zoom_iters=20):
+    if not 0 < c1 < c2 < 1:
+        raise ValueError("strong_wolfe requires 0 < c1 < c2 < 1")
+
+    if max_iters < 1:
+        raise ValueError("strong_wolfe requires max_iters >= 1")
+
+    if zoom_iters < 1:
+        raise ValueError("strong_wolfe requires zoom_iters >= 1")
+
+    if not bool(dphi0 < 0):
+        raise ValueError("strong_wolfe requires a descent direction with dphi0 < 0")
+
+    alpha_prev = phi0.new_zeros(())
+    phi_prev = phi0
+    alpha = _as_scalar_tensor(alpha0, phi0)
+    phi_alpha = phi(alpha)
+
+    for iteration in range(max_iters):
+        if bool((phi_alpha > phi0 + c1 * alpha * dphi0) or (iteration > 0 and phi_alpha >= phi_prev)):
+            return _strong_wolfe_zoom(phi, dphi, phi0, dphi0, alpha_prev, alpha, phi_prev, c1, c2, zoom_iters)
+
+        dphi_alpha = dphi(alpha)
+        if bool(torch.abs(dphi_alpha) <= -c2 * dphi0):
+            return alpha, phi_alpha, dphi_alpha
+
+        if bool(dphi_alpha >= 0):
+            return _strong_wolfe_zoom(phi, dphi, phi0, dphi0, alpha, alpha_prev, phi_alpha, c1, c2, zoom_iters)
+
+        alpha_prev = alpha
+        phi_prev = phi_alpha
+        alpha = alpha * 2.0
+        phi_alpha = phi(alpha)
+
+    dphi_alpha = dphi(alpha)
+    return alpha, phi_alpha, dphi_alpha

--- a/tests/test_line_search.py
+++ b/tests/test_line_search.py
@@ -1,0 +1,51 @@
+import torch
+
+from optimizers import line_search
+
+
+def _quadratic_phi(alpha):
+    return 0.5 * (1 - alpha) ** 2
+
+
+def _quadratic_dphi(alpha):
+    return alpha - 1
+
+
+def test_line_search_submodule_exports_public_functions():
+    assert callable(line_search.armijo_backtracking)
+    assert callable(line_search.strong_wolfe)
+
+
+def test_armijo_backtracking_satisfies_sufficient_decrease():
+    phi0 = _quadratic_phi(torch.tensor(0.0))
+    dphi0 = _quadratic_dphi(torch.tensor(0.0))
+
+    alpha, phi_alpha = line_search.armijo_backtracking(
+        phi=_quadratic_phi,
+        phi0=phi0,
+        dphi0=dphi0,
+        alpha0=torch.tensor(2.0),
+    )
+
+    assert isinstance(alpha, torch.Tensor)
+    assert isinstance(phi_alpha, torch.Tensor)
+    assert bool(phi_alpha <= phi0 + 1e-4 * alpha * dphi0)
+
+
+def test_strong_wolfe_satisfies_conditions():
+    phi0 = _quadratic_phi(torch.tensor(0.0))
+    dphi0 = _quadratic_dphi(torch.tensor(0.0))
+
+    alpha, phi_alpha, dphi_alpha = line_search.strong_wolfe(
+        phi=_quadratic_phi,
+        dphi=_quadratic_dphi,
+        phi0=phi0,
+        dphi0=dphi0,
+        alpha0=torch.tensor(2.0),
+    )
+
+    assert isinstance(alpha, torch.Tensor)
+    assert isinstance(phi_alpha, torch.Tensor)
+    assert isinstance(dphi_alpha, torch.Tensor)
+    assert bool(phi_alpha <= phi0 + 1e-4 * alpha * dphi0)
+    assert bool(torch.abs(dphi_alpha) <= 0.9 * torch.abs(dphi0))


### PR DESCRIPTION
## Summary
- add a public `optimizers.line_search` module with generic pure-PyTorch Armijo and strong-Wolfe line search functions
- expose the submodule through the package API
- add standalone tests for Armijo sufficient decrease and strong Wolfe conditions

Notes:
- this PR only adds the public line-search functions and tests
- it does not yet wire them into `LevenbergMarquardt` or other optimizers