### PR TITLE
fix: scale genetic mutation strength

### DIFF
--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -90,7 +90,7 @@ class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
     @torch.no_grad
     def mutate(self, genome):
         mask = torch.rand_like(genome) < self.mutation_rate
-        noise = torch.randn_like(genome)*self.mutation_strength**2
+        noise = torch.randn_like(genome)*self.mutation_strength
 
         genome[mask] += noise[mask]
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -218,6 +218,20 @@ def test_genetic_step_runs_with_scalar_parameter_vector():
     assert isinstance(loss, torch.Tensor)
 
 
+def test_genetic_mutation_strength_scales_noise(monkeypatch):
+    x = torch.nn.Parameter(torch.zeros(3))
+    optimizer = Genetic([x])
+    optimizer.mutation_rate = 1.0
+    optimizer.mutation_strength = 0.1
+
+    monkeypatch.setattr(torch, "rand_like", lambda tensor: torch.zeros_like(tensor))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor: torch.ones_like(tensor))
+
+    mutated = optimizer.mutate(torch.zeros_like(x))
+
+    assert torch.equal(mutated, torch.full_like(x, 0.1))
+
+
 def test_genetic_state_dict_restores_population_and_elite_state():
     x = _scalar_param()
     optimizer = Genetic([x])


### PR DESCRIPTION
## Summary
- scale genetic mutation noise directly by `mutation_strength` instead of `mutation_strength**2`
- add a deterministic regression test for mutation noise scaling

## Verification
- `uv run --group dev pytest tests/test_runtime.py`

Closes #53