### PR TITLE
fix: reject non-descent Newton steps

### DIFF
--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -97,7 +97,7 @@ class Newton(torch.optim.Optimizer):
         dphi0 = g @ direction
 
         if not bool(dphi0 < 0):
-            self._set_params(params, base_params + direction)
+            self._set_params(params, base_params)
             return
 
         def phi(alpha):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -80,6 +80,20 @@ def test_newton_wolfe_line_search_step_runs():
     optimizer.step(lambda: (x ** 2).sum())
 
 
+def test_newton_line_search_keeps_params_on_non_descent_direction(monkeypatch):
+    x = _scalar_param()
+    optimizer = Newton([x], line_search_method="armijo")
+
+    def non_descent_direction(system, rhs):
+        return -rhs
+
+    monkeypatch.setattr(torch.linalg, "solve", non_descent_direction)
+
+    optimizer.step(lambda: (x ** 2).sum())
+
+    assert x.item() == pytest.approx(1.0)
+
+
 def test_annealing_step_runs():
     x = _scalar_param()
     optimizer = Annealing([x])


### PR DESCRIPTION
## Summary
- keep Newton parameters unchanged when line search receives a non-descent direction
- add a regression test that forces the non-descent fallback path

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py`

Closes #54