### PR TITLE
fix: use Joseph covariance update

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -104,7 +104,8 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
 
         P = self.P / self.tau + self.Q
 
-        A = H @ P @ H.T + ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+        R = ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+        A = H @ P @ H.T + R
 
         K = torch.linalg.solve(A, H @ P).T
 
@@ -112,6 +113,8 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
 
         self.update_weights(updates)
 
-        self.P = P - K @ H @ P
+        I = torch.eye(self.numel, device=P.device, dtype=P.dtype)
+        IKH = I - K @ H
+        self.P = IKH @ P @ IKH.T + K @ R @ K.T
 
         return self.loss(closure())

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -99,7 +99,8 @@ class KalmanFilter(torch.optim.Optimizer):
 
         P = self.P / self.tau + self.Q
 
-        A = H @ P @ H.T + ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+        R = ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+        A = H @ P @ H.T + R
 
         K = torch.linalg.solve(A, H @ P).T
 
@@ -107,7 +108,9 @@ class KalmanFilter(torch.optim.Optimizer):
 
         self.update_weights(updates)
 
-        self.P = P - K @ H @ P
+        I = torch.eye(self.numel, device=P.device, dtype=P.dtype)
+        IKH = I - K @ H
+        self.P = IKH @ P @ IKH.T + K @ R @ K.T
 
         errors, _ = closure()
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -386,6 +386,29 @@ def test_extended_kalman_filter_q_update_changes_Q():
     assert optimizer.Q[0, 0].item() == pytest.approx(5.0)
 
 
+def _kalman_covariance_problem():
+    dtype = torch.float64
+    x = torch.nn.Parameter(torch.tensor([1.5, -1.0], dtype=dtype))
+    A = torch.tensor([[2.0, 0.5], [-1.0, 1.5]], dtype=dtype)
+    b = torch.tensor([1.0, -0.5], dtype=dtype)
+    return x, A, b
+
+
+def _assert_positive_definite_covariance(P):
+    assert torch.allclose(P, P.T, atol=1e-10)
+    assert torch.linalg.eigvalsh(P).min().item() > 0
+
+
+def test_extended_kalman_filter_covariance_stays_positive_definite():
+    x, A, b = _kalman_covariance_problem()
+    optimizer = ExtendedKalmanFilter([x])
+
+    for _ in range(20):
+        optimizer.step(lambda: A @ x - b)
+
+    _assert_positive_definite_covariance(optimizer.P)
+
+
 def test_kalman_filter_step_runs():
     x = _scalar_param()
     optimizer = KalmanFilter([x])
@@ -440,3 +463,13 @@ def test_kalman_filter_q_update_changes_Q():
     optimizer.q = 5.0
 
     assert optimizer.Q[0, 0].item() == pytest.approx(5.0)
+
+
+def test_kalman_filter_covariance_stays_positive_definite():
+    x, A, b = _kalman_covariance_problem()
+    optimizer = KalmanFilter([x])
+
+    for _ in range(20):
+        optimizer.step(lambda: (A @ x - b, A))
+
+    _assert_positive_definite_covariance(optimizer.P)


### PR DESCRIPTION
## Summary
- update EKF and KF covariance with the Joseph form for better numerical stability
- add covariance symmetry and positive-definiteness regression tests for EKF and KF

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py`

Closes #69
Closes #64