### PR TITLE
fix: remove unused optimizer imports

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -1,7 +1,6 @@
 import torch
 
 from ._utils import _FlatParamOptimizerMixin
-from ._utils import all_params
 from ._utils import trainable_params
 
 

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,5 +1,4 @@
 import torch
-from .Newton import Newton
 from ._utils import _FlatParamOptimizerMixin
 from ._utils import trainable_params
 
@@ -26,7 +25,6 @@ class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
         self.population += torch.randn_like(self.population) * 1e-0
 
         self.helper = torch.optim.Adam(self.param_groups)
-        # self.helper = Newton(self.param_groups[0]['params'])
 
     def _state_param(self):
         return trainable_params(self.param_groups)[0]

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -1,7 +1,6 @@
 import torch
 
 from ._utils import _FlatParamOptimizerMixin
-from ._utils import all_params
 from ._utils import trainable_params
 
 


### PR DESCRIPTION
## Summary
- remove unused `all_params` imports from Annealing and Metropolis
- remove unused `Newton` import and stale commented helper line from Genetic

## Verification
- `uv run --group dev pytest tests/test_runtime.py`

Closes #59
Closes #71