### PR TITLE
test: strengthen line search contracts

### DIFF
--- a/tests/test_line_search.py
+++ b/tests/test_line_search.py
@@ -11,6 +11,14 @@ def _quadratic_dphi(alpha):
     return alpha - 1
 
 
+def _quartic_phi(alpha):
+    return (alpha - 0.25) ** 2 + 0.1 * alpha ** 4
+
+
+def _quartic_dphi(alpha):
+    return 2 * (alpha - 0.25) + 0.4 * alpha ** 3
+
+
 def test_line_search_submodule_exports_public_functions():
     assert callable(line_search.armijo_backtracking)
     assert callable(line_search.strong_wolfe)
@@ -47,5 +55,39 @@ def test_strong_wolfe_satisfies_conditions():
     assert isinstance(alpha, torch.Tensor)
     assert isinstance(phi_alpha, torch.Tensor)
     assert isinstance(dphi_alpha, torch.Tensor)
+    assert bool(phi_alpha <= phi0 + 1e-4 * alpha * dphi0)
+    assert bool(torch.abs(dphi_alpha) <= 0.9 * torch.abs(dphi0))
+
+
+def test_armijo_backtracking_shrinks_too_large_step():
+    phi0 = _quartic_phi(torch.tensor(0.0))
+    dphi0 = _quartic_dphi(torch.tensor(0.0))
+    alpha0 = torch.tensor(1.0)
+
+    alpha, phi_alpha = line_search.armijo_backtracking(
+        phi=_quartic_phi,
+        phi0=phi0,
+        dphi0=dphi0,
+        alpha0=alpha0,
+    )
+
+    assert bool(alpha < alpha0)
+    assert bool(phi_alpha <= phi0 + 1e-4 * alpha * dphi0)
+
+
+def test_strong_wolfe_handles_nontrivial_zoom_interval():
+    phi0 = _quartic_phi(torch.tensor(0.0))
+    dphi0 = _quartic_dphi(torch.tensor(0.0))
+    alpha0 = torch.tensor(1.0)
+
+    alpha, phi_alpha, dphi_alpha = line_search.strong_wolfe(
+        phi=_quartic_phi,
+        dphi=_quartic_dphi,
+        phi0=phi0,
+        dphi0=dphi0,
+        alpha0=alpha0,
+    )
+
+    assert bool(0 < alpha < alpha0)
     assert bool(phi_alpha <= phi0 + 1e-4 * alpha * dphi0)
     assert bool(torch.abs(dphi_alpha) <= 0.9 * torch.abs(dphi0))


### PR DESCRIPTION
## Summary
- add a non-trivial quartic line-search objective
- verify Armijo backtracking actually shrinks an oversized step
- verify strong Wolfe handles the resulting zoom interval

## Verification
- `uv run --group dev pytest tests/test_line_search.py`

Closes #62