### PR TITLE
fix: enable grad in Newton step

### DIFF
--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -61,6 +61,7 @@ class Newton(torch.optim.Optimizer):
 
     def step(self, closure: callable):
         assert len(self.param_groups) == 1
+        closure = torch.enable_grad()(closure)
 
         params = trainable_params(self.param_groups)
         prototype = params[0]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -25,6 +25,16 @@ def test_newton_step_runs():
     optimizer.step(lambda: (x ** 2).sum())
 
 
+def test_newton_step_runs_inside_no_grad_context():
+    x = _scalar_param()
+    optimizer = Newton([x])
+
+    with torch.no_grad():
+        optimizer.step(lambda: (x ** 2).sum())
+
+    assert x.item() != pytest.approx(1.0)
+
+
 def test_newton_step_runs_with_float64():
     x = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.float64))
     optimizer = Newton([x])


### PR DESCRIPTION
## Summary
- make Newton re-enable grad for its closure inside `step()` like the other autodiff optimizers
- add a regression test for calling Newton under an outer `torch.no_grad()` context

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py`

Closes #70