### PR TITLE
feat: expose Newton damping

### DIFF
--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -10,8 +10,8 @@ from .line_search import strong_wolfe
 
 
 class Newton(torch.optim.Optimizer):
-    def __init__(self, params, line_search_method=None):
-        super().__init__(params, dict(line_search_method=line_search_method))
+    def __init__(self, params, line_search_method=None, damping=1e-4):
+        super().__init__(params, dict(line_search_method=line_search_method, damping=damping))
 
         params = trainable_params(self.param_groups)
         self.numel = sum(
@@ -22,6 +22,7 @@ class Newton(torch.optim.Optimizer):
             raise ValueError("Newton requires at least one trainable parameter")
 
         self.line_search_method = line_search_method
+        self.damping = damping
 
     def _canonical_line_search_method(self, value):
         aliases = {
@@ -44,6 +45,14 @@ class Newton(torch.optim.Optimizer):
     @line_search_method.setter
     def line_search_method(self, value):
         self.param_groups[0]['line_search_method'] = self._canonical_line_search_method(value)
+
+    @property
+    def damping(self):
+        return self.param_groups[0]['damping']
+
+    @damping.setter
+    def damping(self, value):
+        self.param_groups[0]['damping'] = value
     
     @property
     def params(self):
@@ -84,7 +93,7 @@ class Newton(torch.optim.Optimizer):
                     grad(g[idx], params, create_graph=True, retain_graph=True, allow_unused=True)
                 )
             ])
-        H += 1e-4 * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype) # damping for num. stability
+        H += self.damping * torch.eye(self.numel, device=prototype.device, dtype=prototype.dtype)
 
         direction = torch.linalg.solve(H, -g)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -32,6 +32,29 @@ def test_newton_step_runs_with_float64():
     optimizer.step(lambda: (x ** 2).sum())
 
 
+def test_newton_damping_controls_regularization():
+    undamped = _scalar_param()
+    damped = _scalar_param()
+
+    Newton([undamped], damping=0.0).step(lambda: (undamped ** 2).sum())
+    Newton([damped], damping=2.0).step(lambda: (damped ** 2).sum())
+
+    assert undamped.item() == pytest.approx(0.0)
+    assert damped.item() == pytest.approx(0.5)
+
+
+def test_newton_state_dict_restores_damping():
+    x = _scalar_param()
+    optimizer = Newton([x], damping=0.25)
+    state_dict = optimizer.state_dict()
+
+    y = _scalar_param()
+    restored = Newton([y])
+    restored.load_state_dict(state_dict)
+
+    assert restored.damping == pytest.approx(0.25)
+
+
 def test_newton_rejects_multiple_param_groups():
     x = _scalar_param()
     y = _scalar_param(2.0)


### PR DESCRIPTION
## Summary
- add a configurable `damping` parameter to Newton with the existing `1e-4` default
- use the configured damping in the Hessian regularization term
- add tests for damping behavior and state-dict restoration

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py`

Closes #67