### PR TITLE
fix: reduce Kalman closure work

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -96,11 +96,9 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
 
         assert len(self.param_groups) == 1
 
-        closure = torch.enable_grad()(closure)
-
-        errors = closure()
-        
-        H = self.jacobian(errors)
+        with torch.enable_grad():
+            errors = closure()
+            H = self.jacobian(errors)
 
         P = self.P / self.tau + self.Q
 
@@ -117,4 +115,5 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
         IKH = I - K @ H
         self.P = IKH @ P @ IKH.T + K @ R @ K.T
 
-        return self.loss(closure())
+        with torch.no_grad():
+            return self.loss(closure())

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -92,10 +92,9 @@ class KalmanFilter(torch.optim.Optimizer):
 
         assert len(self.param_groups) == 1
 
-        closure = torch.enable_grad()(closure)
-
-        errors, H = closure()
-        errors = errors.view(-1)
+        with torch.no_grad():
+            errors, H = closure()
+        errors = errors.view(-1).clone()
 
         P = self.P / self.tau + self.Q
 
@@ -112,6 +111,4 @@ class KalmanFilter(torch.optim.Optimizer):
         IKH = I - K @ H
         self.P = IKH @ P @ IKH.T + K @ R @ K.T
 
-        errors, _ = closure()
-
-        return self.loss(errors.view(-1))
+        return self.loss((errors + H @ updates).view(-1))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -414,6 +414,20 @@ def test_extended_kalman_filter_q_update_changes_Q():
     assert optimizer.Q[0, 0].item() == pytest.approx(5.0)
 
 
+def test_extended_kalman_filter_return_loss_closure_runs_without_grad():
+    x = _scalar_param()
+    optimizer = ExtendedKalmanFilter([x])
+    grad_modes = []
+
+    def closure():
+        grad_modes.append(torch.is_grad_enabled())
+        return x.view(-1)
+
+    optimizer.step(closure)
+
+    assert grad_modes == [True, False]
+
+
 def _kalman_covariance_problem():
     dtype = torch.float64
     x = torch.nn.Parameter(torch.tensor([1.5, -1.0], dtype=dtype))
@@ -491,6 +505,23 @@ def test_kalman_filter_q_update_changes_Q():
     optimizer.q = 5.0
 
     assert optimizer.Q[0, 0].item() == pytest.approx(5.0)
+
+
+def test_kalman_filter_step_evaluates_closure_once():
+    x, A, b = _kalman_covariance_problem()
+    optimizer = KalmanFilter([x])
+    calls = 0
+
+    def closure():
+        nonlocal calls
+        calls += 1
+        return A @ x - b, A
+
+    loss = optimizer.step(closure)
+
+    expected_errors = A @ x - b
+    assert calls == 1
+    assert loss.item() == pytest.approx((expected_errors @ expected_errors).item())
 
 
 def test_kalman_filter_covariance_stays_positive_definite():


### PR DESCRIPTION
## Summary
- evaluate EKF's return-loss closure under `torch.no_grad()`
- avoid KalmanFilter's second closure call by using the exact linear residual update
- add regression tests for EKF grad mode and KF closure call count

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py`

Closes #57