### PR TITLE
refactor: share Kalman update logic

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -1,6 +1,7 @@
 import torch
 
 from ._utils import add_flat_update_
+from ._utils import kalman_update
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
@@ -100,20 +101,17 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
             errors = closure()
             H = self.jacobian(errors)
 
-        P = self.P / self.tau + self.Q
-
-        R = ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
-        A = H @ P @ H.T + R
-
-        K = torch.linalg.solve(A, H @ P).T
-
-        updates = -(K @ errors).view(-1)
+        updates, self.P, _ = kalman_update(
+            errors=errors,
+            H=H,
+            P=self.P,
+            Q=self.Q,
+            eta=self.eta,
+            eps=self.eps,
+            tau=self.tau,
+        )
 
         self.update_weights(updates)
-
-        I = torch.eye(self.numel, device=P.device, dtype=P.dtype)
-        IKH = I - K @ H
-        self.P = IKH @ P @ IKH.T + K @ R @ K.T
 
         with torch.no_grad():
             return self.loss(closure())

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -1,6 +1,7 @@
 import torch
 
 from ._utils import add_flat_update_
+from ._utils import kalman_update
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
 
@@ -94,21 +95,17 @@ class KalmanFilter(torch.optim.Optimizer):
 
         with torch.no_grad():
             errors, H = closure()
-        errors = errors.view(-1).clone()
 
-        P = self.P / self.tau + self.Q
-
-        R = ((1 / self.eta) + self.eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
-        A = H @ P @ H.T + R
-
-        K = torch.linalg.solve(A, H @ P).T
-
-        updates = -(K @ errors).view(-1)
+        updates, self.P, linearized_errors = kalman_update(
+            errors=errors,
+            H=H,
+            P=self.P,
+            Q=self.Q,
+            eta=self.eta,
+            eps=self.eps,
+            tau=self.tau,
+        )
 
         self.update_weights(updates)
 
-        I = torch.eye(self.numel, device=P.device, dtype=P.dtype)
-        IKH = I - K @ H
-        self.P = IKH @ P @ IKH.T + K @ R @ K.T
-
-        return self.loss((errors + H @ updates).view(-1))
+        return self.loss(linearized_errors.view(-1))

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -70,6 +70,23 @@ def residual_sum_squares(errors):
     return errors @ errors
 
 
+def kalman_update(errors, H, P, Q, eta, eps, tau):
+    errors = errors.view(-1).clone()
+    P = P / tau + Q
+
+    R = ((1 / eta) + eps) * torch.eye(errors.shape[0], device=errors.device, dtype=errors.dtype)
+    A = H @ P @ H.T + R
+
+    K = torch.linalg.solve(A, H @ P).T
+    updates = -(K @ errors).view(-1)
+
+    I = torch.eye(P.shape[0], device=P.device, dtype=P.dtype)
+    IKH = I - K @ H
+    next_P = IKH @ P @ IKH.T + K @ R @ K.T
+
+    return updates, next_P, errors + H @ updates
+
+
 class _FlatParamOptimizerMixin:
     @property
     def params(self):


### PR DESCRIPTION
## Summary
- extract the shared Kalman gain, Joseph covariance update, and state update math into `_utils.kalman_update`
- keep EKF and KF closure contracts separate while sharing the backend algebra

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py tests/test_devices.py`

Closes #58