### PR TITLE
refactor: share line search option parsing

### DIFF
--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -6,6 +6,7 @@ from ._utils import load_flat_params_
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
+from .line_search import _canonical_line_search_method
 from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
@@ -60,21 +61,6 @@ class LevenbergMarquardt(torch.optim.Optimizer):
 
         return aliases[value]
 
-    def _canonical_line_search_method(self, value):
-        aliases = {
-            "armijo": "armijo",
-            "wolfe": "wolfe",
-            "strong wolfe": "wolfe",
-            "strong_wolfe": "wolfe",
-        }
-
-        if value not in aliases:
-            raise ValueError(
-                "LevenbergMarquardt line_search_method must be 'armijo' or 'wolfe'"
-            )
-
-        return aliases[value]
-
     @property
     def mu(self):
         return self.param_groups[0]['mu']
@@ -117,11 +103,17 @@ class LevenbergMarquardt(torch.optim.Optimizer):
 
     @property
     def line_search_method(self):
-        return self._canonical_line_search_method(self.param_groups[0]['line_search_method'])
+        return _canonical_line_search_method(
+            self.param_groups[0]['line_search_method'],
+            optimizer_name="LevenbergMarquardt",
+        )
 
     @line_search_method.setter
     def line_search_method(self, value):
-        self.param_groups[0]['line_search_method'] = self._canonical_line_search_method(value)
+        self.param_groups[0]['line_search_method'] = _canonical_line_search_method(
+            value,
+            optimizer_name="LevenbergMarquardt",
+        )
 
     def jacobian(self, targets):
         return residual_jacobian(targets, trainable_params(self.param_groups))

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -5,6 +5,7 @@ from ._utils import add_flat_update_
 from ._utils import flat_params
 from ._utils import load_flat_params_
 from ._utils import trainable_params
+from .line_search import _canonical_line_search_method
 from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
@@ -24,27 +25,21 @@ class Newton(torch.optim.Optimizer):
         self.line_search_method = line_search_method
         self.damping = damping
 
-    def _canonical_line_search_method(self, value):
-        aliases = {
-            None: None,
-            "armijo": "armijo",
-            "wolfe": "wolfe",
-            "strong wolfe": "wolfe",
-            "strong_wolfe": "wolfe",
-        }
-
-        if value not in aliases:
-            raise ValueError("Newton line_search_method must be None, 'armijo', or 'wolfe'")
-
-        return aliases[value]
-
     @property
     def line_search_method(self):
-        return self._canonical_line_search_method(self.param_groups[0]['line_search_method'])
+        return _canonical_line_search_method(
+            self.param_groups[0]['line_search_method'],
+            allow_none=True,
+            optimizer_name="Newton",
+        )
 
     @line_search_method.setter
     def line_search_method(self, value):
-        self.param_groups[0]['line_search_method'] = self._canonical_line_search_method(value)
+        self.param_groups[0]['line_search_method'] = _canonical_line_search_method(
+            value,
+            allow_none=True,
+            optimizer_name="Newton",
+        )
 
     @property
     def damping(self):

--- a/src/optimizers/line_search.py
+++ b/src/optimizers/line_search.py
@@ -1,6 +1,24 @@
 import torch
 
 
+def _canonical_line_search_method(value, allow_none=False, optimizer_name="optimizer"):
+    aliases = {
+        "armijo": "armijo",
+        "wolfe": "wolfe",
+        "strong wolfe": "wolfe",
+        "strong_wolfe": "wolfe",
+    }
+
+    if allow_none:
+        aliases[None] = None
+
+    if value not in aliases:
+        allowed = "None, 'armijo', or 'wolfe'" if allow_none else "'armijo' or 'wolfe'"
+        raise ValueError(f"{optimizer_name} line_search_method must be {allowed}")
+
+    return aliases[value]
+
+
 def _as_scalar_tensor(value, reference):
     if isinstance(value, torch.Tensor):
         return value.to(device=reference.device, dtype=reference.dtype).reshape(())

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -113,6 +113,12 @@ def test_newton_wolfe_line_search_step_runs():
     optimizer.step(lambda: (x ** 2).sum())
 
 
+def test_newton_accepts_strong_wolfe_alias():
+    optimizer = Newton([_scalar_param()], line_search_method="strong_wolfe")
+
+    assert optimizer.line_search_method == "wolfe"
+
+
 def test_newton_line_search_keeps_params_on_non_descent_direction(monkeypatch):
     x = _scalar_param()
     optimizer = Newton([x], line_search_method="armijo")
@@ -453,6 +459,12 @@ def test_levenberg_marquardt_wolfe_line_search_step_runs():
     loss = optimizer.step(lambda: x.view(-1))
 
     assert isinstance(loss, float)
+
+
+def test_levenberg_marquardt_accepts_strong_wolfe_alias():
+    optimizer = LevenbergMarquardt([_scalar_param()], line_search_method="strong_wolfe")
+
+    assert optimizer.line_search_method == "wolfe"
 
 
 def test_extended_kalman_filter_step_runs():


### PR DESCRIPTION
## Summary
- move shared line-search method alias parsing into `line_search.py`
- remove duplicated Newton/LM alias maps while preserving existing accepted values
- keep scalar param-group properties explicit to preserve readability for numerical users

## Verification
- `uv run --group dev pytest tests/test_line_search.py tests/test_runtime.py tests/test_progress.py`

Closes #55