### PR TITLE
refactor: share flat update helpers

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -1,13 +1,13 @@
 import torch
 
-from ._utils import add_flat_update_
+from ._utils import _FlatUpdateOptimizerMixin
 from ._utils import kalman_update
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
 
 
-class ExtendedKalmanFilter(torch.optim.Optimizer):
+class ExtendedKalmanFilter(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
     """Extended Kalman filter optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to
@@ -89,10 +89,6 @@ class ExtendedKalmanFilter(torch.optim.Optimizer):
     def loss(self, errors):
         return residual_sum_squares(errors)
     
-    @torch.no_grad()
-    def update_weights(self, updates):
-        add_flat_update_(trainable_params(self.param_groups), updates)
-
     def step(self, closure = None):
 
         assert len(self.param_groups) == 1

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -1,8 +1,7 @@
 import torch
 
-from ._utils import add_flat_update_
+from ._utils import _FlatUpdateOptimizerMixin
 from ._utils import flat_params
-from ._utils import load_flat_params_
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
@@ -11,7 +10,7 @@ from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class LevenbergMarquardt(torch.optim.Optimizer):
+class LevenbergMarquardt(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
     """Levenberg-Marquardt optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to
@@ -122,14 +121,6 @@ class LevenbergMarquardt(torch.optim.Optimizer):
     def loss(self, errors):
         return residual_sum_squares(errors)
     
-    @torch.no_grad()
-    def update_weights(self, update):
-        add_flat_update_(trainable_params(self.param_groups), update)
-
-    @torch.no_grad()
-    def _set_params(self, params, values):
-        load_flat_params_(params, values)
-
     def _lm_step(self, J, errors):
         damping = self.mu + self.solve_epsilon
         system = J.T @ J + damping * torch.eye(

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -1,23 +1,21 @@
 import torch
 from torch.autograd import grad
 
-from ._utils import add_flat_update_
+from ._utils import _FlatUpdateOptimizerMixin
 from ._utils import flat_params
-from ._utils import load_flat_params_
 from ._utils import trainable_params
 from .line_search import _canonical_line_search_method
 from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class Newton(torch.optim.Optimizer):
+class Newton(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
     """Dense Newton optimizer for scalar-loss closures.
 
     This optimizer explicitly materializes the full Hessian of all trainable
     parameters. It is intended for small parameter vectors where dense
     second-order linear algebra is practical.
     """
-
     def __init__(self, params, line_search_method=None, damping=1e-4):
         super().__init__(params, dict(line_search_method=line_search_method, damping=damping))
 
@@ -61,14 +59,6 @@ class Newton(torch.optim.Optimizer):
         return torch.cat([
             p.flatten() for group in self.param_groups for p in group['params']
         ])
-
-    @torch.no_grad()
-    def update_weights(self, update):
-        add_flat_update_(trainable_params(self.param_groups), update)
-
-    @torch.no_grad()
-    def _set_params(self, params, values):
-        load_flat_params_(params, values)
 
     def step(self, closure: callable):
         assert len(self.param_groups) == 1

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -95,3 +95,13 @@ class _FlatParamOptimizerMixin:
     @torch.no_grad()
     def update_weights(self, update):
         load_flat_params_(trainable_params(self.param_groups), update)
+
+
+class _FlatUpdateOptimizerMixin:
+    @torch.no_grad()
+    def update_weights(self, update):
+        add_flat_update_(trainable_params(self.param_groups), update)
+
+    @torch.no_grad()
+    def _set_params(self, params, values):
+        load_flat_params_(params, values)


### PR DESCRIPTION
## Summary
- add a separate additive flat-update mixin for second-order/Kalman optimizers
- remove duplicate `update_weights` and `_set_params` wrappers from Newton, LM, and EKF
- keep the existing absolute flat-parameter mixin unchanged for Annealing/Metropolis/Genetic

## Verification
- `uv run --group dev pytest tests/test_runtime.py tests/test_progress.py tests/test_devices.py`

Closes #56