### PR TITLE
docs: document Newton Hessian scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ The public `optimizers.line_search` submodule exposes pure-PyTorch callback-base
 `KalmanFilter` is the linear-residual variant. `ExtendedKalmanFilter` computes the residual Jacobian internally.
 
 `Newton` defaults to the full Newton step when `line_search_method=None`. `LevenbergMarquardt` defaults to `strategy="line search"` and also accepts the compatibility aliases `"line_search"`, `"trust_region"`, and `"heuristic"`.
+
+## Scaling Notes
+
+`Newton` builds and solves a dense Hessian over all trainable parameters, so it is intended for small systems where exact second-order steps are practical. Use the Kalman or stochastic optimizers for experiments where forming a dense Hessian is too expensive.

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -10,6 +10,13 @@ from .line_search import strong_wolfe
 
 
 class Newton(torch.optim.Optimizer):
+    """Dense Newton optimizer for scalar-loss closures.
+
+    This optimizer explicitly materializes the full Hessian of all trainable
+    parameters. It is intended for small parameter vectors where dense
+    second-order linear algebra is practical.
+    """
+
     def __init__(self, params, line_search_method=None, damping=1e-4):
         super().__init__(params, dict(line_search_method=line_search_method, damping=damping))
 


### PR DESCRIPTION
## Summary
- document that Newton materializes a dense Hessian over all trainable parameters
- add a README scaling note for users choosing optimizers for larger experiments

## Verification
- `uv run --group dev python3 -c "from optimizers import Newton; assert 'Dense Newton optimizer' in Newton.__doc__"`

Closes #68