### PR TITLE
build: add NumPy dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Issues = "https://github.com/kovacoj/optimizers/issues"
 
 [dependency-groups]
 dev = [
+    "numpy>=2.1",
     "pytest>=8.4.2",
 ]
 


### PR DESCRIPTION
## Summary
- add NumPy to the dev dependency group so Torch initializes cleanly during tests
- keep NumPy out of runtime dependencies because the package code does not import it

## Verification
- `uv sync --group dev`
- `uv run --group dev python3 -c "import numpy; import torch; print(numpy.__version__)"`
- `uv run --group dev pytest tests/test_line_search.py`

Closes #89