### PR TITLE
fix: replace assert with ValueError for param group validation

### DIFF
--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -91,7 +91,8 @@ class ExtendedKalmanFilter(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
     
     def step(self, closure = None):
 
-        assert len(self.param_groups) == 1
+        if len(self.param_groups) != 1:
+            raise ValueError("ExtendedKalmanFilter requires exactly one parameter group")
 
         with torch.enable_grad():
             errors = closure()

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -91,7 +91,8 @@ class KalmanFilter(torch.optim.Optimizer):
 
     def step(self, closure = None):
 
-        assert len(self.param_groups) == 1
+        if len(self.param_groups) != 1:
+            raise ValueError("KalmanFilter requires exactly one parameter group")
 
         with torch.no_grad():
             errors, H = closure()

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -201,7 +201,8 @@ class LevenbergMarquardt(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
 
     def step(self, closure = None):
 
-        assert len(self.param_groups) == 1
+        if len(self.param_groups) != 1:
+            raise ValueError("LevenbergMarquardt requires exactly one parameter group")
 
         closure = torch.enable_grad()(closure)
 

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -61,7 +61,8 @@ class Newton(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
         ])
 
     def step(self, closure: callable):
-        assert len(self.param_groups) == 1
+        if len(self.param_groups) != 1:
+            raise ValueError("Newton requires exactly one parameter group")
         closure = torch.enable_grad()(closure)
 
         params = trainable_params(self.param_groups)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -73,7 +73,7 @@ def test_newton_rejects_multiple_param_groups():
         {"params": [y]},
     ])
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         optimizer.step(lambda: (x ** 2).sum() + (y ** 2).sum())
 
 


### PR DESCRIPTION
Replaces `assert len(self.param_groups) == 1` with explicit `if`/`raise ValueError(...)` in Newton, LevenbergMarquardt, ExtendedKalmanFilter, and KalmanFilter. `assert` is stripped by Python `-O` flag, silently removing the check.

Closes #95