### PR TITLE
fix: remove Newton.params override that shadows base class

### DIFF
--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -54,12 +54,6 @@ class Newton(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
     def damping(self, value):
         self.param_groups[0]['damping'] = value
     
-    @property
-    def params(self):
-        return torch.cat([
-            p.flatten() for group in self.param_groups for p in group['params']
-        ])
-
     def step(self, closure: callable):
         if len(self.param_groups) != 1:
             raise ValueError("Newton requires exactly one parameter group")


### PR DESCRIPTION
Newton's `params` property used all params (including non-trainable), shadowing the inherited `_FlatUpdateOptimizerMixin.params` which correctly uses `trainable_params()`. Removed the override so the base class trainable-only version is used consistently.

Closes #98