### PR TITLE
refactor: rename Mixin base classes to flat optimizer bases

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -1,10 +1,10 @@
 import torch
 
-from ._utils import _FlatParamOptimizerMixin
+from ._utils import _FlatParamOptimizer
 from ._utils import trainable_params
 
 
-class Annealing(_FlatParamOptimizerMixin, torch.optim.Optimizer):
+class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, dict(temperature=1.0)) 
 

--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -1,13 +1,13 @@
 import torch
 
-from ._utils import _FlatUpdateOptimizerMixin
+from ._utils import _FlatUpdateOptimizer
 from ._utils import kalman_update
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
 
 
-class ExtendedKalmanFilter(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
+class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
     """Extended Kalman filter optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,9 +1,9 @@
 import torch
-from ._utils import _FlatParamOptimizerMixin
+from ._utils import _FlatParamOptimizer
 from ._utils import trainable_params
 
 
-class Genetic(_FlatParamOptimizerMixin, torch.optim.Optimizer):
+class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, dict(
             mutation_rate=0.1,

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -1,6 +1,6 @@
 import torch
 
-from ._utils import _FlatUpdateOptimizerMixin
+from ._utils import _FlatUpdateOptimizer
 from ._utils import flat_params
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
@@ -10,7 +10,7 @@ from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class LevenbergMarquardt(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
+class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
     """Levenberg-Marquardt optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -1,10 +1,10 @@
 import torch
 
-from ._utils import _FlatParamOptimizerMixin
+from ._utils import _FlatParamOptimizer
 from ._utils import trainable_params
 
 
-class Metropolis(_FlatParamOptimizerMixin, torch.optim.Optimizer):
+class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
     def __init__(self, params):
         super().__init__(params, dict(temperature=10.0)) 
 

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -1,7 +1,7 @@
 import torch
 from torch.autograd import grad
 
-from ._utils import _FlatUpdateOptimizerMixin
+from ._utils import _FlatUpdateOptimizer
 from ._utils import flat_params
 from ._utils import trainable_params
 from .line_search import _canonical_line_search_method
@@ -9,7 +9,7 @@ from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class Newton(_FlatUpdateOptimizerMixin, torch.optim.Optimizer):
+class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
     """Dense Newton optimizer for scalar-loss closures.
 
     This optimizer explicitly materializes the full Hessian of all trainable

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -87,7 +87,7 @@ def kalman_update(errors, H, P, Q, eta, eps, tau):
     return updates, next_P, errors + H @ updates
 
 
-class _FlatParamOptimizerMixin:
+class _FlatParamOptimizer:
     @property
     def params(self):
         return flat_params(trainable_params(self.param_groups))
@@ -97,7 +97,7 @@ class _FlatParamOptimizerMixin:
         load_flat_params_(trainable_params(self.param_groups), update)
 
 
-class _FlatUpdateOptimizerMixin:
+class _FlatUpdateOptimizer:
     @torch.no_grad()
     def update_weights(self, update):
         add_flat_update_(trainable_params(self.param_groups), update)


### PR DESCRIPTION
Renames `_FlatParamOptimizerMixin` → `_FlatParamOptimizer` and `_FlatUpdateOptimizerMixin` → `_FlatUpdateOptimizer`. These are core base classes, not optional behavior-adders; the "Mixin" suffix was misleading.

Closes #91