### PR TITLE
fix: consistent closure type hints in step() signatures

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 
 from ._utils import _FlatParamOptimizer
@@ -29,7 +31,7 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
         )*self.temperature
 
     @torch.no_grad
-    def step(self, closure):
+    def step(self, closure: Callable):
         variants = [self.params, self.mutate().clone()]
         Fs = torch.empty(2)
 

--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 
 from ._utils import _FlatUpdateOptimizer
@@ -89,7 +91,7 @@ class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
     def loss(self, errors):
         return residual_sum_squares(errors)
     
-    def step(self, closure = None):
+    def step(self, closure: Callable):
 
         if len(self.param_groups) != 1:
             raise ValueError("ExtendedKalmanFilter requires exactly one parameter group")

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 from ._utils import _FlatParamOptimizer
 from ._utils import trainable_params
@@ -119,7 +121,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
         return closure()
 
     # @torch.no_grad
-    def step(self, closure):
+    def step(self, closure: Callable):
         loss = torch.empty(self.pop_size)
 
         for idx in range(self.pop_size):            

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 
 from ._utils import add_flat_update_
@@ -89,7 +91,7 @@ class KalmanFilter(torch.optim.Optimizer):
     def update_weights(self, updates):
         add_flat_update_(trainable_params(self.param_groups), updates)
 
-    def step(self, closure = None):
+    def step(self, closure: Callable):
 
         if len(self.param_groups) != 1:
             raise ValueError("KalmanFilter requires exactly one parameter group")

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 
 from ._utils import _FlatUpdateOptimizer
@@ -199,7 +201,7 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
 
         return base_loss.item()
 
-    def step(self, closure = None):
+    def step(self, closure: Callable):
 
         if len(self.param_groups) != 1:
             raise ValueError("LevenbergMarquardt requires exactly one parameter group")

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 
 from ._utils import _FlatParamOptimizer
@@ -31,7 +33,7 @@ class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
         return proposal
 
     @torch.no_grad
-    def step(self, closure):
+    def step(self, closure: Callable):
         variants = [self.params, self.mutate().clone()]
         Fs = torch.empty(2)
 

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import torch
 from torch.autograd import grad
 
@@ -54,7 +56,7 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
     def damping(self, value):
         self.param_groups[0]['damping'] = value
     
-    def step(self, closure: callable):
+    def step(self, closure: Callable):
         if len(self.param_groups) != 1:
             raise ValueError("Newton requires exactly one parameter group")
         closure = torch.enable_grad()(closure)


### PR DESCRIPTION
Standardizes `closure` parameter across all `step()` methods to `closure: Callable`. Removes misleading `= None` default (closure is always required). Uses `collections.abc.Callable` instead of `callable` builtin.

Closes #99