### PR TITLE
style: use @torch.no_grad() consistently everywhere

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -24,13 +24,13 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
     def temperature(self, value):
         self.param_groups[0]['temperature'] = value
 
-    @torch.no_grad
+    @torch.no_grad()
     def mutate(self):
         return self.params + torch.randn_like(
             self.params
         )*self.temperature
 
-    @torch.no_grad
+    @torch.no_grad()
     def step(self, closure: Callable):
         variants = [self.params, self.mutate().clone()]
         Fs = torch.empty(2)

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -87,7 +87,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
     def population(self, value):
         self.state[self._state_param()]['population'] = value
 
-    @torch.no_grad
+    @torch.no_grad()
     def mutate(self, genome):
         mask = torch.rand_like(genome) < self.mutation_rate
         noise = torch.randn_like(genome)*self.mutation_strength
@@ -96,7 +96,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
 
         return genome
 
-    @torch.no_grad
+    @torch.no_grad()
     def crossover(self, parent1, parent2):
         if self.numel < 2:
             return parent1.clone(), parent2.clone()
@@ -108,7 +108,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
 
         return child1.clone(), child2.clone()
 
-    # @torch.no_grad
+    @torch.no_grad()
     def directional(self, closure, steps=0):
         self.helper.state.clear()
 
@@ -120,7 +120,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
 
         return closure()
 
-    # @torch.no_grad
+    @torch.no_grad()
     def step(self, closure: Callable):
         loss = torch.empty(self.pop_size)
 

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -24,7 +24,7 @@ class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
     def temperature(self, value):
         self.param_groups[0]['temperature'] = value
 
-    @torch.no_grad
+    @torch.no_grad()
     def mutate(self, ):
         proposal = self.params.clone()
         idx = torch.randint(low=0, high=self.numel, size=()).item()
@@ -32,7 +32,7 @@ class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
 
         return proposal
 
-    @torch.no_grad
+    @torch.no_grad()
     def step(self, closure: Callable):
         variants = [self.params, self.mutate().clone()]
         Fs = torch.empty(2)


### PR DESCRIPTION
Standardizes `@torch.no_grad()` (with parens) across all optimizer methods. Uncommented the two commented-out decorators in Genetic.py. Closes #96.