### PR TITLE
feat: expose cooling_rate and noise_scale as parameters

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -7,8 +7,8 @@ from ._utils import trainable_params
 
 
 class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
-    def __init__(self, params):
-        super().__init__(params, dict(temperature=1.0)) 
+    def __init__(self, params, cooling_rate=1e-3):
+        super().__init__(params, dict(temperature=1.0, cooling_rate=cooling_rate)) 
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
@@ -23,6 +23,14 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
     @temperature.setter
     def temperature(self, value):
         self.param_groups[0]['temperature'] = value
+
+    @property
+    def cooling_rate(self):
+        return self.param_groups[0]['cooling_rate']
+
+    @cooling_rate.setter
+    def cooling_rate(self, value):
+        self.param_groups[0]['cooling_rate'] = value
 
     @torch.no_grad()
     def mutate(self):
@@ -44,6 +52,6 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
         )).item())
 
         self.update_weights(variants[idx])
-        self.temperature *= 1 - 1e-3
+        self.temperature *= 1 - self.cooling_rate
 
         return closure()

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -6,12 +6,13 @@ from ._utils import trainable_params
 
 
 class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
-    def __init__(self, params):
+    def __init__(self, params, noise_scale=1.0):
         super().__init__(params, dict(
             mutation_rate=0.1,
             mutation_strength=0.1,
             elite_ratio=0.2,
             pop_size=100,
+            noise_scale=noise_scale,
         )) 
 
         params = trainable_params(self.param_groups)
@@ -24,7 +25,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
         self.best_fitness = float('inf')
 
         self.population = self.params.unsqueeze(0).repeat(self.pop_size, 1)
-        self.population += torch.randn_like(self.population) * 1e-0
+        self.population += torch.randn_like(self.population) * self.noise_scale
 
         self.helper = torch.optim.Adam(self.param_groups)
 
@@ -62,6 +63,14 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
     @pop_size.setter
     def pop_size(self, value):
         self.param_groups[0]['pop_size'] = value
+
+    @property
+    def noise_scale(self):
+        return self.param_groups[0]['noise_scale']
+
+    @noise_scale.setter
+    def noise_scale(self, value):
+        self.param_groups[0]['noise_scale'] = value
 
     @property
     def best_genome(self):

--- a/src/optimizers/Metropolis.py
+++ b/src/optimizers/Metropolis.py
@@ -7,8 +7,8 @@ from ._utils import trainable_params
 
 
 class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
-    def __init__(self, params):
-        super().__init__(params, dict(temperature=10.0)) 
+    def __init__(self, params, cooling_rate=1e-3):
+        super().__init__(params, dict(temperature=10.0, cooling_rate=cooling_rate)) 
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
@@ -23,6 +23,14 @@ class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
     @temperature.setter
     def temperature(self, value):
         self.param_groups[0]['temperature'] = value
+
+    @property
+    def cooling_rate(self):
+        return self.param_groups[0]['cooling_rate']
+
+    @cooling_rate.setter
+    def cooling_rate(self, value):
+        self.param_groups[0]['cooling_rate'] = value
 
     @torch.no_grad()
     def mutate(self, ):
@@ -46,6 +54,6 @@ class Metropolis(_FlatParamOptimizer, torch.optim.Optimizer):
         )).item())
 
         self.update_weights(variants[idx])
-        self.temperature *= 1 - 1e-3
+        self.temperature *= 1 - self.cooling_rate
 
         return closure()


### PR DESCRIPTION
Adds configurable parameters for previously hardcoded values:
- `cooling_rate` on Annealing and Metropolis (default `1e-3`)
- `noise_scale` on Genetic (default `1.0`)
- Replaced confusing `1e-0` with `1.0` in Genetic population init

Closes #97