### PR TITLE
refactor: add _ParamGroupDefault descriptor to reduce boilerplate

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -3,10 +3,14 @@ from collections.abc import Callable
 import torch
 
 from ._utils import _FlatParamOptimizer
+from ._utils import _ParamGroupDefault
 from ._utils import trainable_params
 
 
 class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
+    temperature = _ParamGroupDefault()
+    cooling_rate = _ParamGroupDefault()
+
     def __init__(self, params, cooling_rate=1e-3):
         super().__init__(params, dict(temperature=1.0, cooling_rate=cooling_rate)) 
 
@@ -15,22 +19,6 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
 
         if self.numel == 0:
             raise ValueError("Annealing requires at least one trainable parameter")
-
-    @property
-    def temperature(self):
-        return self.param_groups[0]['temperature']
-
-    @temperature.setter
-    def temperature(self, value):
-        self.param_groups[0]['temperature'] = value
-
-    @property
-    def cooling_rate(self):
-        return self.param_groups[0]['cooling_rate']
-
-    @cooling_rate.setter
-    def cooling_rate(self, value):
-        self.param_groups[0]['cooling_rate'] = value
 
     @torch.no_grad()
     def mutate(self):

--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import torch
 
 from ._utils import _FlatUpdateOptimizer
+from ._utils import _ParamGroupDefault
 from ._utils import kalman_update
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
@@ -17,6 +18,11 @@ class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
     optimizer state, while `eta`, `eps`, `q`, and `tau` are live properties on
     the single param group.
     """
+
+    eta = _ParamGroupDefault()
+    eps = _ParamGroupDefault()
+    q = _ParamGroupDefault()
+    tau = _ParamGroupDefault()
 
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
         defaults = dict(
@@ -39,38 +45,6 @@ class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
             device=params[0].device,
             dtype=params[0].dtype,
         )
-
-    @property
-    def eta(self):
-        return self.param_groups[0]['eta']
-
-    @eta.setter
-    def eta(self, value):
-        self.param_groups[0]['eta'] = value
-
-    @property
-    def eps(self):
-        return self.param_groups[0]['eps']
-
-    @eps.setter
-    def eps(self, value):
-        self.param_groups[0]['eps'] = value
-
-    @property
-    def q(self):
-        return self.param_groups[0]['q']
-
-    @q.setter
-    def q(self, value):
-        self.param_groups[0]['q'] = value
-
-    @property
-    def tau(self):
-        return self.param_groups[0]['tau']
-
-    @tau.setter
-    def tau(self, value):
-        self.param_groups[0]['tau'] = value
 
     @property
     def P(self):

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -2,10 +2,17 @@ from collections.abc import Callable
 
 import torch
 from ._utils import _FlatParamOptimizer
+from ._utils import _ParamGroupDefault
 from ._utils import trainable_params
 
 
 class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
+    mutation_rate = _ParamGroupDefault()
+    mutation_strength = _ParamGroupDefault()
+    elite_ratio = _ParamGroupDefault()
+    pop_size = _ParamGroupDefault()
+    noise_scale = _ParamGroupDefault()
+
     def __init__(self, params, noise_scale=1.0):
         super().__init__(params, dict(
             mutation_rate=0.1,
@@ -31,46 +38,6 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
 
     def _state_param(self):
         return trainable_params(self.param_groups)[0]
-
-    @property
-    def mutation_rate(self):
-        return self.param_groups[0]['mutation_rate']
-
-    @mutation_rate.setter
-    def mutation_rate(self, value):
-        self.param_groups[0]['mutation_rate'] = value
-
-    @property
-    def mutation_strength(self):
-        return self.param_groups[0]['mutation_strength']
-
-    @mutation_strength.setter
-    def mutation_strength(self, value):
-        self.param_groups[0]['mutation_strength'] = value
-
-    @property
-    def elite_ratio(self):
-        return self.param_groups[0]['elite_ratio']
-
-    @elite_ratio.setter
-    def elite_ratio(self, value):
-        self.param_groups[0]['elite_ratio'] = value
-
-    @property
-    def pop_size(self):
-        return self.param_groups[0]['pop_size']
-
-    @pop_size.setter
-    def pop_size(self, value):
-        self.param_groups[0]['pop_size'] = value
-
-    @property
-    def noise_scale(self):
-        return self.param_groups[0]['noise_scale']
-
-    @noise_scale.setter
-    def noise_scale(self, value):
-        self.param_groups[0]['noise_scale'] = value
 
     @property
     def best_genome(self):

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import torch
 
+from ._utils import _ParamGroupDefault
 from ._utils import add_flat_update_
 from ._utils import kalman_update
 from ._utils import residual_sum_squares
@@ -16,6 +17,11 @@ class KalmanFilter(torch.optim.Optimizer):
     linear observation matrix. The covariance `P` is persistent optimizer
     state, while `eta`, `eps`, `q`, and `tau` are live param-group properties.
     """
+
+    eta = _ParamGroupDefault()
+    eps = _ParamGroupDefault()
+    q = _ParamGroupDefault()
+    tau = _ParamGroupDefault()
 
     def __init__(self, params, eta = 1e3, eps = 1e-3, q = 1e-6, tau = 1):
         defaults = dict(
@@ -38,38 +44,6 @@ class KalmanFilter(torch.optim.Optimizer):
             device=params[0].device,
             dtype=params[0].dtype,
         )
-
-    @property
-    def eta(self):
-        return self.param_groups[0]['eta']
-
-    @eta.setter
-    def eta(self, value):
-        self.param_groups[0]['eta'] = value
-
-    @property
-    def eps(self):
-        return self.param_groups[0]['eps']
-
-    @eps.setter
-    def eps(self, value):
-        self.param_groups[0]['eps'] = value
-
-    @property
-    def q(self):
-        return self.param_groups[0]['q']
-
-    @q.setter
-    def q(self, value):
-        self.param_groups[0]['q'] = value
-
-    @property
-    def tau(self):
-        return self.param_groups[0]['tau']
-
-    @tau.setter
-    def tau(self, value):
-        self.param_groups[0]['tau'] = value
 
     @property
     def P(self):

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import torch
 
 from ._utils import _FlatUpdateOptimizer
+from ._utils import _ParamGroupDefault
 from ._utils import flat_params
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
@@ -23,6 +24,11 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
     `step()` returns the final residual sum of squares as a Python float, so
     callers can keep any loss history externally.
     """
+
+    mu = _ParamGroupDefault()
+    mu_factor = _ParamGroupDefault()
+    m_max = _ParamGroupDefault()
+    solve_epsilon = _ParamGroupDefault()
 
     def __init__(self, params, mu = 10**3, mu_factor = 5, m_max = 10, strategy = "line search", line_search_method = "armijo", solve_epsilon = 1e-8):
         defaults = dict(mu = mu,
@@ -61,38 +67,6 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
             )
 
         return aliases[value]
-
-    @property
-    def mu(self):
-        return self.param_groups[0]['mu']
-
-    @mu.setter
-    def mu(self, value):
-        self.param_groups[0]['mu'] = value
-
-    @property
-    def mu_factor(self):
-        return self.param_groups[0]['mu_factor']
-
-    @mu_factor.setter
-    def mu_factor(self, value):
-        self.param_groups[0]['mu_factor'] = value
-
-    @property
-    def m_max(self):
-        return self.param_groups[0]['m_max']
-
-    @m_max.setter
-    def m_max(self, value):
-        self.param_groups[0]['m_max'] = value
-
-    @property
-    def solve_epsilon(self):
-        return self.param_groups[0]['solve_epsilon']
-
-    @solve_epsilon.setter
-    def solve_epsilon(self, value):
-        self.param_groups[0]['solve_epsilon'] = value
 
     @property
     def strategy(self):

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -4,6 +4,7 @@ import torch
 from torch.autograd import grad
 
 from ._utils import _FlatUpdateOptimizer
+from ._utils import _ParamGroupDefault
 from ._utils import flat_params
 from ._utils import trainable_params
 from .line_search import _canonical_line_search_method
@@ -18,6 +19,8 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
     parameters. It is intended for small parameter vectors where dense
     second-order linear algebra is practical.
     """
+    damping = _ParamGroupDefault()
+
     def __init__(self, params, line_search_method=None, damping=1e-4):
         super().__init__(params, dict(line_search_method=line_search_method, damping=damping))
 
@@ -47,14 +50,6 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
             allow_none=True,
             optimizer_name="Newton",
         )
-
-    @property
-    def damping(self):
-        return self.param_groups[0]['damping']
-
-    @damping.setter
-    def damping(self, value):
-        self.param_groups[0]['damping'] = value
     
     def step(self, closure: Callable):
         if len(self.param_groups) != 1:

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -87,6 +87,19 @@ def kalman_update(errors, H, P, Q, eta, eps, tau):
     return updates, next_P, errors + H @ updates
 
 
+class _ParamGroupDefault:
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return obj.param_groups[0][self.name]
+
+    def __set__(self, obj, value):
+        obj.param_groups[0][self.name] = value
+
+
 class _FlatParamOptimizer:
     @property
     def params(self):


### PR DESCRIPTION
Adds `_ParamGroupDefault` descriptor to `_utils.py` that replaces the repetitive `@property`/`@setter` boilerplate for simple `param_groups[0]['key']` passthroughs.

Replaced boilerplate in: Newton (damping), LevenbergMarquardt (mu, mu_factor, m_max, solve_epsilon), ExtendedKalmanFilter (eta, eps, q, tau), KalmanFilter (eta, eps, q, tau), Annealing (temperature, cooling_rate), Genetic (mutation_rate, mutation_strength, elite_ratio, pop_size, noise_scale).

Kept as explicit properties where custom validation is needed (strategy, line_search_method).

Closes #100