### PR TITLE
refactor: remove _FlatParamOptimizer and _FlatUpdateOptimizer base classes

### DIFF
--- a/src/optimizers/Annealing.py
+++ b/src/optimizers/Annealing.py
@@ -2,23 +2,28 @@ from collections.abc import Callable
 
 import torch
 
-from ._utils import _FlatParamOptimizer
 from ._utils import _ParamGroupDefault
+from ._utils import flat_params
+from ._utils import load_flat_params_
 from ._utils import trainable_params
 
 
-class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
+class Annealing(torch.optim.Optimizer):
     temperature = _ParamGroupDefault()
     cooling_rate = _ParamGroupDefault()
 
     def __init__(self, params, cooling_rate=1e-3):
-        super().__init__(params, dict(temperature=1.0, cooling_rate=cooling_rate)) 
+        super().__init__(params, dict(temperature=1.0, cooling_rate=cooling_rate))
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
 
         if self.numel == 0:
             raise ValueError("Annealing requires at least one trainable parameter")
+
+    @property
+    def params(self):
+        return flat_params(trainable_params(self.param_groups))
 
     @torch.no_grad()
     def mutate(self):
@@ -32,14 +37,14 @@ class Annealing(_FlatParamOptimizer, torch.optim.Optimizer):
         Fs = torch.empty(2)
 
         for idx, params in enumerate(variants):
-            self.update_weights(params)
+            load_flat_params_(trainable_params(self.param_groups), params)
             Fs[idx] = closure().item()
 
         idx = int((torch.rand(1) < torch.exp(
             (Fs[0] - Fs[1]) / self.temperature
         )).item())
 
-        self.update_weights(variants[idx])
+        load_flat_params_(trainable_params(self.param_groups), variants[idx])
         self.temperature *= 1 - self.cooling_rate
 
         return closure()

--- a/src/optimizers/ExtendedKalmanFilter.py
+++ b/src/optimizers/ExtendedKalmanFilter.py
@@ -2,15 +2,15 @@ from collections.abc import Callable
 
 import torch
 
-from ._utils import _FlatUpdateOptimizer
 from ._utils import _ParamGroupDefault
+from ._utils import add_flat_update_
 from ._utils import kalman_update
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
 
 
-class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
+class ExtendedKalmanFilter(torch.optim.Optimizer):
     """Extended Kalman filter optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to
@@ -84,7 +84,7 @@ class ExtendedKalmanFilter(_FlatUpdateOptimizer, torch.optim.Optimizer):
             tau=self.tau,
         )
 
-        self.update_weights(updates)
+        add_flat_update_(trainable_params(self.param_groups), updates)
 
         with torch.no_grad():
             return self.loss(closure())

--- a/src/optimizers/Genetic.py
+++ b/src/optimizers/Genetic.py
@@ -1,12 +1,13 @@
 from collections.abc import Callable
 
 import torch
-from ._utils import _FlatParamOptimizer
 from ._utils import _ParamGroupDefault
+from ._utils import flat_params
+from ._utils import load_flat_params_
 from ._utils import trainable_params
 
 
-class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
+class Genetic(torch.optim.Optimizer):
     mutation_rate = _ParamGroupDefault()
     mutation_strength = _ParamGroupDefault()
     elite_ratio = _ParamGroupDefault()
@@ -20,7 +21,7 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
             elite_ratio=0.2,
             pop_size=100,
             noise_scale=noise_scale,
-        )) 
+        ))
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
@@ -35,6 +36,10 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
         self.population += torch.randn_like(self.population) * self.noise_scale
 
         self.helper = torch.optim.Adam(self.param_groups)
+
+    @property
+    def params(self):
+        return flat_params(trainable_params(self.param_groups))
 
     def _state_param(self):
         return trainable_params(self.param_groups)[0]
@@ -92,7 +97,6 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
             self.helper.zero_grad()
             closure().backward()
             self.helper.step()
-            # self.helper.step(closure)
 
         return closure()
 
@@ -100,12 +104,11 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
     def step(self, closure: Callable):
         loss = torch.empty(self.pop_size)
 
-        for idx in range(self.pop_size):            
-            self.update_weights(self.population[idx])
+        for idx in range(self.pop_size):
+            load_flat_params_(trainable_params(self.param_groups), self.population[idx])
             loss[idx] = self.directional(closure)
             self.population[idx] = self.params.clone()
 
-        # TRACK BEST INDIVIDUAL (ELITISM)
         best_idx = torch.argmin(loss)
         current_best_fitness = loss[best_idx].item()
 
@@ -113,32 +116,27 @@ class Genetic(_FlatParamOptimizer, torch.optim.Optimizer):
             self.best_fitness = current_best_fitness
             self.best_genome = self.population[best_idx].clone()
 
-        # SELECTION (Truncation Selection)
         num_parents = max(1, int(self.pop_size * self.elite_ratio))
         sorted_indices = torch.argsort(loss, descending=False)
         parent_indices = sorted_indices[:num_parents]
         parents = self.population[parent_indices]
 
-        # REPRODUCTION
         new_population = [self.best_genome.clone()]
 
         while len(new_population) < self.pop_size:
             p1_idx, p2_idx = torch.randint(0, num_parents, (2,)).unbind()
-            
+
             p1 = parents[p1_idx]
             p2 = parents[p2_idx]
 
-            # Crossover
             child1, child2 = self.crossover(p1, p2)
 
-            # Mutation
             new_population.append(self.mutate(child1))
             if len(new_population) < self.pop_size:
                 new_population.append(self.mutate(child2))
 
         self.population = torch.stack(new_population)
 
-        # pdate best weights for external calls to model(x)
-        self.update_weights(self.best_genome)
+        load_flat_params_(trainable_params(self.param_groups), self.best_genome)
 
         return closure()

--- a/src/optimizers/KalmanFilter.py
+++ b/src/optimizers/KalmanFilter.py
@@ -60,10 +60,6 @@ class KalmanFilter(torch.optim.Optimizer):
 
     def loss(self, errors):
         return residual_sum_squares(errors)
-    
-    @torch.no_grad()
-    def update_weights(self, updates):
-        add_flat_update_(trainable_params(self.param_groups), updates)
 
     def step(self, closure: Callable):
 
@@ -83,6 +79,6 @@ class KalmanFilter(torch.optim.Optimizer):
             tau=self.tau,
         )
 
-        self.update_weights(updates)
+        add_flat_update_(trainable_params(self.param_groups), updates)
 
         return self.loss(linearized_errors.view(-1))

--- a/src/optimizers/LevenbergMarquardt.py
+++ b/src/optimizers/LevenbergMarquardt.py
@@ -2,9 +2,10 @@ from collections.abc import Callable
 
 import torch
 
-from ._utils import _FlatUpdateOptimizer
 from ._utils import _ParamGroupDefault
+from ._utils import add_flat_update_
 from ._utils import flat_params
+from ._utils import load_flat_params_
 from ._utils import residual_jacobian
 from ._utils import residual_sum_squares
 from ._utils import trainable_params
@@ -13,7 +14,7 @@ from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
+class LevenbergMarquardt(torch.optim.Optimizer):
     """Levenberg-Marquardt optimizer for residual-vector closures.
 
     This optimizer assumes a single parameter group and expects `closure()` to
@@ -43,7 +44,6 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
 
         params = trainable_params(self.param_groups)
         self.numel = sum(param.numel() for param in params)
-        # self.numel = reduce(lambda total, p: total + p.numel(), self.param_groups, 0)
 
         if self.numel == 0:
             raise ValueError("LevenbergMarquardt requires at least one trainable parameter")
@@ -112,11 +112,11 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
         direction = self._lm_step(J, errors)
 
         def phi(alpha):
-            self._set_params(params, base_params + alpha * direction)
+            load_flat_params_(params, base_params + alpha * direction)
             return 0.5 * self.loss(closure())
 
         def dphi(alpha):
-            self._set_params(params, base_params + alpha * direction)
+            load_flat_params_(params, base_params + alpha * direction)
             trial_errors = closure()
             trial_jacobian = self.jacobian(trial_errors)
             return (trial_jacobian.T @ trial_errors) @ direction
@@ -143,7 +143,7 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
                 max_iters=self.m_max + 1,
             )
 
-        self._set_params(params, base_params + alpha * direction)
+        load_flat_params_(params, base_params + alpha * direction)
         return (2.0 * phi_alpha).item()
 
     def _step_trust_region(self, closure, J, errors, base_loss):
@@ -160,7 +160,7 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
                 nu *= 2.0
                 continue
 
-            self.update_weights(updates)
+            add_flat_update_(trainable_params(self.param_groups), updates)
             new_loss = self.loss(closure())
             actual_reduction = base_loss - new_loss
             rho = actual_reduction / predicted_reduction
@@ -169,7 +169,7 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
                 self.mu *= max(1 / 3, 1 - (2 * rho - 1) ** 3)
                 return new_loss.item()
 
-            self.update_weights(-updates)
+            add_flat_update_(trainable_params(self.param_groups), -updates)
             self.mu *= nu
             nu *= 2.0
 
@@ -185,7 +185,6 @@ class LevenbergMarquardt(_FlatUpdateOptimizer, torch.optim.Optimizer):
         errors = closure()
         base_loss = self.loss(errors)
         
-        # compute Jacobian matrix
         J = self.jacobian(errors)
 
         if self.strategy == "trust region":

--- a/src/optimizers/Newton.py
+++ b/src/optimizers/Newton.py
@@ -3,16 +3,17 @@ from collections.abc import Callable
 import torch
 from torch.autograd import grad
 
-from ._utils import _FlatUpdateOptimizer
 from ._utils import _ParamGroupDefault
+from ._utils import add_flat_update_
 from ._utils import flat_params
+from ._utils import load_flat_params_
 from ._utils import trainable_params
 from .line_search import _canonical_line_search_method
 from .line_search import armijo_backtracking
 from .line_search import strong_wolfe
 
 
-class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
+class Newton(torch.optim.Optimizer):
     """Dense Newton optimizer for scalar-loss closures.
 
     This optimizer explicitly materializes the full Hessian of all trainable
@@ -83,7 +84,7 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
         direction = torch.linalg.solve(H, -g)
 
         if self.line_search_method is None:
-            self.update_weights(direction)
+            add_flat_update_(trainable_params(self.param_groups), direction)
             return
 
         base_params = flat_params(params).clone()
@@ -91,15 +92,15 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
         dphi0 = g @ direction
 
         if not bool(dphi0 < 0):
-            self._set_params(params, base_params)
+            load_flat_params_(params, base_params)
             return
 
         def phi(alpha):
-            self._set_params(params, base_params + alpha * direction)
+            load_flat_params_(params, base_params + alpha * direction)
             return closure()
 
         def dphi(alpha):
-            self._set_params(params, base_params + alpha * direction)
+            load_flat_params_(params, base_params + alpha * direction)
             grads = grad(closure(), params, create_graph=True, allow_unused=True)
             gradient = torch.cat([
                 grad_.reshape(-1) if grad_ is not None else param.new_zeros(param.numel())
@@ -123,4 +124,4 @@ class Newton(_FlatUpdateOptimizer, torch.optim.Optimizer):
                 alpha0=loss0.new_tensor(1.0),
             )
 
-        self._set_params(params, base_params + alpha * direction)
+        load_flat_params_(params, base_params + alpha * direction)

--- a/src/optimizers/_utils.py
+++ b/src/optimizers/_utils.py
@@ -100,21 +100,4 @@ class _ParamGroupDefault:
         obj.param_groups[0][self.name] = value
 
 
-class _FlatParamOptimizer:
-    @property
-    def params(self):
-        return flat_params(trainable_params(self.param_groups))
 
-    @torch.no_grad()
-    def update_weights(self, update):
-        load_flat_params_(trainable_params(self.param_groups), update)
-
-
-class _FlatUpdateOptimizer:
-    @torch.no_grad()
-    def update_weights(self, update):
-        add_flat_update_(trainable_params(self.param_groups), update)
-
-    @torch.no_grad()
-    def _set_params(self, params, values):
-        load_flat_params_(params, values)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -165,7 +165,8 @@ def test_stochastic_step_acceptance_uses_explicit_index(optimizer_cls, monkeypat
     optimizer.step(closure)
     assert x.item() == pytest.approx(2.0)
 
-    optimizer.update_weights(torch.tensor([1.0]))
+    from optimizers._utils import load_flat_params_, trainable_params
+    load_flat_params_(trainable_params(optimizer.param_groups), torch.tensor([1.0]))
     monkeypatch.setattr(torch, "rand", lambda *args, **kwargs: torch.tensor([1.0]))
     optimizer.step(closure)
     assert x.item() == pytest.approx(1.0)


### PR DESCRIPTION
Inlines `update_weights`, `_set_params`, and `params` into each optimizer using the underlying `_utils` functions directly (`add_flat_update_`, `load_flat_params_`, `flat_params`). Removes the two base classes which were thin wrappers adding no logic beyond delegation.

Closes #91 (the "Mixin" naming is now moot since the classes are gone).